### PR TITLE
Update pbr: remove sync slowdown ?

### DIFF
--- a/files/etc/init.d/pbr
+++ b/files/etc/init.d/pbr
@@ -814,7 +814,6 @@ cleanup_rt_tables() {
 	for i in $(grep -oh "${ipTablePrefix}_.*" "$rtTablesFile"); do
 		! is_netifd_table "$i" && sed -i "/${i}/d" "$rtTablesFile"
 	done
-	sync
 }
 
 cleanup_main_chains() {
@@ -1566,7 +1565,6 @@ interface_routing() {
 				if ! grep -q "$tid ${ipTablePrefix}_${iface}" "$rtTablesFile"; then
 					sed -i "/${ipTablePrefix}_${iface}/d" "$rtTablesFile"
 					echo "$tid ${ipTablePrefix}_${iface}" >> "$rtTablesFile"
-					sync
 				fi
 				ip -4 rule flush table "$tid" >/dev/null 2>&1
 				ip -4 route flush table "$tid" >/dev/null 2>&1
@@ -1659,7 +1657,6 @@ EOF
 				ip rule flush table "$tid" >/dev/null 2>&1
 				ip route flush table "$tid" >/dev/null 2>&1
 				sed -i "/${ipTablePrefix}_${iface}\$/d" "$rtTablesFile"
-				sync
 			fi
 			return "$s"
 		;;
@@ -2225,7 +2222,6 @@ setup_netifd() {
 			if ! grep -q "$tid ${ipTablePrefix}_${iface%6}" "$rtTablesFile"; then
 				sed -i "/${ipTablePrefix}_${iface%6}/d" "$rtTablesFile"
 				echo "$tid ${ipTablePrefix}_${iface%6}" >> "$rtTablesFile"
-				sync
 			fi
 			uci_set 'network' "${iface}" 'ip4table' "${ipTablePrefix}_${iface%6}"
 			uci_set 'network' "${iface}" 'ip6table' "${ipTablePrefix}_${iface%6}"
@@ -2254,12 +2250,10 @@ setup_netifd() {
 		output_okbn
 	}
 	sed -i "/${ipTablePrefix}_/d" "$rtTablesFile"
-	sync
 	config_load 'network'
 	config_foreach _pbr_iface_setup 'interface' "$param"
 	_pbr_default_route_setup "$param"
 	uci_commit 'network'
-	sync
 	output "Restarting network ${param:+($param) }"
 	/etc/init.d/network restart
 	output_okn


### PR DESCRIPTION
What's the reason to use sync? Most of it runs in-memory or on a tmpfs. If you let Linux handle it will save about ~5 seconds in a restart.

I only see it used in the following init files with a good reason:
* boot: to cement initial config generation.
* done: after removal of sysupgrade (substantial file size)
* uhttpd to cement the certificate
* umount to cement pending writes

I experience no issues by removing them.

before:
```
# time /etc/init.d/pbr restart
real	0m 7.62s
user	0m 1.31s
sys	0m 0.37s
```
after:
```
# time ./pbr restart
real	0m 2.37s
user	0m 1.33s
sys	0m 0.40s
```