### PR TITLE
pbr: enhance dnsmasq debug output

### DIFF
--- a/files/etc/init.d/pbr
+++ b/files/etc/init.d/pbr
@@ -316,8 +316,8 @@ check_dnsmasq_nftset() {
 	check_dnsmasq || return 1
 	o="$(dnsmasq -v 2>/dev/null)"
 	{ 
-		echo 'dnsmasq output dump';
-		echo "$o"; 
+		echo " $(date) dnsmasq output dump:";
+		echo  "${o%$'\n'$'\n'This*}"; 
 		echo '-------------------------'; 
 	} >> "$packageDebugFile"
 	! echo "$o" | grep -q 'no-nftset' && echo "$o" | grep -q 'nftset'


### PR DESCRIPTION
This patch enhances dnsmasq debug out put in /var/run/pbr.debug

It adds the date/time but removes the  following unnecessary lines:
```

This software comes with ABSOLUTELY NO WARRANTY.
Dnsmasq is free software, and you are welcome to redistribute it
under the terms of the GNU General Public License, version 2 or 3.

```

So in the end it will show like:
```
 Wed Jun  4 14:45:06 CEST 2025 dnsmasq output dump:
Dnsmasq version 2.91  Copyright (c) 2000-2025 Simon Kelley
Compile time options: IPv6 GNU-getopt no-DBus UBus no-i18n no-IDN DHCP DHCPv6 no-Lua TFTP conntrack ipset nftset auth DNSSEC no-ID loop-detect inotify dumpfile
-------------------------
 Wed Jun  4 14:45:14 CEST 2025 dnsmasq output dump:
Dnsmasq version 2.91  Copyright (c) 2000-2025 Simon Kelley
Compile time options: IPv6 GNU-getopt no-DBus UBus no-i18n no-IDN DHCP DHCPv6 no-Lua TFTP conntrack ipset nftset auth DNSSEC no-ID loop-detect inotify dumpfile
-------------------------
``` 
You can discard this PR if you think it is not necessary