### PR TITLE
Fix setup and cleanup of dnsmasq config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=pbr
 PKG_VERSION:=1.1.9
-PKG_RELEASE:=38
+PKG_RELEASE:=39
 PKG_LICENSE:=AGPL-3.0-or-later
 PKG_MAINTAINER:=Stan Grishin <stangri@melmac.ca>
 

--- a/files/etc/init.d/pbr
+++ b/files/etc/init.d/pbr
@@ -638,6 +638,7 @@ load_environment() {
 			output 1 "Loading environment ($param) "
 			load_package_config "$param"
 			load_network "$param"
+			resolver 'check_support'
 			output 1 "$_OK_\n"
 		;;
 	esac
@@ -957,6 +958,7 @@ resolver() {
 				confdir="$(_dnsmasq_instance_get_confdir "$cfg")"
 				[ -n "$confdir" ] && rm -f "${confdir}/${packageName}"
 				uci_remove_list 'dhcp' "$cfg" 'addnmount' "$packageDnsmasqFile"
+				rm -f "$packageDnsmasqFile"
 			;;
 			setup)
 				# add dnsmasq conf addnmounts to point to pbr file
@@ -964,6 +966,7 @@ resolver() {
 				# add softlink to pbr file
 				confdir="$(_dnsmasq_instance_get_confdir "$cfg")"
 				[ -n "$confdir" ] || return 1
+				touch "$packageDnsmasqFile"
 				ln -sf "$packageDnsmasqFile" "${confdir}/${packageName}"
 				chmod 660 "${confdir}/${packageName}"
 				chown -h root:dnsmasq "${confdir}/${packageName}" >/dev/null 2>/dev/null


### PR DESCRIPTION
Fix dnsmasq config not cleaning up properly after 38cc0b6, which leads to duplicate policy entries being added on each restart.