### PR TITLE
Update pbr, remove proto kernel and expires value when copying IPv6 to alternate routing table

### DIFF
--- a/files/etc/init.d/pbr
+++ b/files/etc/init.d/pbr
@@ -1662,6 +1662,7 @@ EOF
 							while read -r i; do
 								i="$(echo "$i" | sed 's/ linkdown$//')"
 								i="$(echo "$i" | sed 's/ onlink$//')"
+								i="$(echo "$i" | sed -E 's/ proto kernel//; s/ expires -?[0-9]+sec//')"
 								# shellcheck disable=SC2086
 								try ip -6 route add $i table "$tid" || ipv6_error=1
 							done << EOF


### PR DESCRIPTION
remove `proto kernel` and `expires value` when copying IPv6 routes to alternate routing table