### PR TITLE
fix: preserve established connections on service restart

### DIFF
--- a/files/etc/init.d/pbr
+++ b/files/etc/init.d/pbr
@@ -815,6 +815,9 @@ nft_file() {
 				mkdir -p "${i%/*}"
 			done
 			{ echo '#!/usr/sbin/nft -f'; echo ''; } > "$nftTempFile"
+			# Preserve established/related connections that already have a routing mark to prevent breaking existing sessions (e.g., SSH)
+			echo "add rule inet $nftTable ${nftPrefix}_prerouting ct state established,related meta mark & $fw_mask != 0 return" >> "$nftTempFile"
+			echo "add rule inet $nftTable ${nftPrefix}_output ct state established,related meta mark & $fw_mask != 0 return" >> "$nftTempFile"
 			# Insert PBR guards at the top of main caller chains so first PBR match wins, while preserving foreign marks.
 			for chain in $chainsList; do
 				echo "add rule inet $nftTable ${nftPrefix}_${chain} ${nftRuleParams:+$nftRuleParams }meta mark & $fw_mask != 0 return" >> "$nftTempFile"


### PR DESCRIPTION
Add connection tracking rules to preserve established/related connections when the PBR service restarts. This prevents existing SSH sessions from being broken when routing rules are flushed and recreated.

The fix adds rules at the top of prerouting and output chains that check for established/related connection state and return early, allowing those packets to continue using their existing routing table.