### PR TITLE
Improve downloaded list file processing: remove comments, empty lines, etc.

### DIFF
--- a/files/etc/init.d/pbr
+++ b/files/etc/init.d/pbr
@@ -546,9 +546,11 @@ process_url() {
 		json add error 'errorDownloadUrlNoHttps' "$url"
 	elif $dl_command "$url" "$dl_flag" "$dl_temp_file" 2>/dev/null; then
 		sed '
-			s/[[:space:]]//g	# remove ALL whitespace characters from each line
-			/^#/d	# remove comment lines starting with #
-			/^$/d	# remove completely empty lines
+			s/[[:space:]]*#.*$//	# remove comments (# and everything after)
+			s/^[[:space:]]*//		# remove leading whitespace
+			s/[[:space:]]*$//		# remove trailing whitespace
+			s/[[:space:]]\+/ /g		# collapse multiple whitespace to single space
+			/^$/d					# remove empty lines
 		' "$dl_temp_file" | sort -u | tr '\n' ' ' # dedupliicate and collapse all remaining lines into a single space-separated line
 	else
 		json add error 'errorDownloadUrl' "$url"


### PR DESCRIPTION
## Summary

This merge request updates the downloaded file list processing pipeline to improve reliability and support for a wider variety of formats.
The changes remove comment lines and empty lines, normalize whitespace, deduplicate entries, and merge all remaining lines into a single space-separated string.

The sed command was rewritten to fix previous errors.

## Example

### Input file (`$dl_temp_file`):

```
# Some plain lines
1.com
2.com
3.com
4.com
5.com
6.com

# Lines with extra spaces and newlines:
   site.com
site2.com


site4.com

# Lines with duplicates:
subdomain.example.com
subdomain.example.com
subdomain.example.com

# CIDR list:
192.168.1.0/24
192.168.2.0/24
172.10.1.1/32
```

### Before changes:
Note that this output is not currently supported because of comments and extra spaces:

```
# List of domains: 1.com
2.com 3.com
4.com 5.com
6.com
# List with extra spaces and newlines: site.com
site2.com
 site4.com
 # List with duplicates:
subdomain.example.com subdomain.example.com
subdomain.example.com
# CIDR list: 192.168.1.0/24
192.168.2.0/24 172.10.1.1/32
```

### After changes:
```
1.com 172.10.1.1/32 192.168.1.0/24 192.168.2.0/24 2.com 3.com 4.com 5.com 6.com site.com site2.com site4.com subdomain.example.com
```
