### PR TITLE
fix: handle disabled/down interfaces in interface_routing

### DIFF
--- a/files/etc/init.d/pbr
+++ b/files/etc/init.d/pbr
@@ -2218,12 +2218,6 @@ interface_routing() {
 					try ip -4 rule replace fwmark "${mark}/${fw_mask}" table "$tid" priority "$priority" || ipv4_error=1
 				fi
 
-				if ! nft_file 'match' 'temp' "${nftPrefix}_mark_${mark}"; then
-					nft add chain inet "$nftTable" "${nftPrefix}_mark_${mark}"
-					nft add rule inet "$nftTable" "${nftPrefix}_mark_${mark} ${nftRuleParams} meta mark set (meta mark & ${fw_maskXor}) | ${mark}"
-					nft add rule inet "$nftTable" "${nftPrefix}_mark_${mark} return"
-				fi
-
 				dscp="$(uci_get "$packageName" 'config' "${iface}_dscp" '0')"
 				if [ "$dscp" -ge '1' ] && [ "$dscp" -le '63' ]; then
 					nft add rule inet "$nftTable" "${nftPrefix}_prerouting ${nftIPv4Flag} dscp ${dscp} ${nftRuleParams} goto ${nftPrefix}_mark_${mark}"
@@ -2231,6 +2225,12 @@ interface_routing() {
 				if [ "$iface" = "$icmp_interface" ]; then
 					nft add rule inet "$nftTable" "${nftPrefix}_output ${nftIPv4Flag} protocol icmp ${nftRuleParams} goto ${nftPrefix}_mark_${mark}"
 				fi
+			elif [ -n "$strict_enforcement" ]; then
+				ipv4_error=0
+				ip -4 rule flush table "$tid" >/dev/null 2>&1
+				ip -4 route flush table "$tid" >/dev/null 2>&1
+				try ip -4 route replace unreachable default table "$tid" || ipv4_error=1
+				try ip -4 rule replace fwmark "${mark}/${fw_mask}" table "$tid" priority "$priority" || ipv4_error=1
 			fi
 
 			if [ -n "$ipv6_enabled" ] && [ -n "$dev6" ]; then
@@ -2256,12 +2256,6 @@ interface_routing() {
 					try ip -6 rule replace fwmark "${mark}/${fw_mask}" table "$tid" priority "$priority" || ipv6_error=1
 				fi
 
-				if ! nft_file 'match' 'temp' "${nftPrefix}_mark_${mark}"; then
-					nft add chain inet "$nftTable" "${nftPrefix}_mark_${mark}"
-					nft add rule inet "$nftTable" "${nftPrefix}_mark_${mark} ${nftRuleParams} meta mark set (meta mark & ${fw_maskXor}) | ${mark}"
-					nft add rule inet "$nftTable" "${nftPrefix}_mark_${mark} return"
-				fi
-
 				dscp="$(uci_get "$packageName" 'config' "${iface}_dscp" '0')"
 				if [ "$dscp" -ge '1' ] && [ "$dscp" -le '63' ]; then
 					nft add rule inet "$nftTable" "${nftPrefix}_prerouting ${nftIPv6Flag} dscp ${dscp} ${nftRuleParams} goto ${nftPrefix}_mark_${mark}"
@@ -2269,6 +2263,19 @@ interface_routing() {
 				if [ "$iface" = "$icmp_interface" ]; then
 					nft add rule inet "$nftTable" "${nftPrefix}_output ${nftIPv6Flag} protocol icmp ${nftRuleParams} goto ${nftPrefix}_mark_${mark}"
 				fi
+			elif [ -n "$ipv6_enabled" ] && [ -n "$strict_enforcement" ]; then
+				ipv6_error=0
+				ip -6 rule flush table "$tid" >/dev/null 2>&1
+				ip -6 route flush table "$tid" >/dev/null 2>&1
+				try ip -6 route replace unreachable default table "$tid" || ipv6_error=1
+				try ip -6 rule replace fwmark "${mark}/${fw_mask}" table "$tid" priority "$priority" || ipv6_error=1
+			fi
+
+			# Always create the nft mark chain so policies can reference it
+			if ! nft_file 'match' 'temp' "${nftPrefix}_mark_${mark}"; then
+				nft add chain inet "$nftTable" "${nftPrefix}_mark_${mark}"
+				nft add rule inet "$nftTable" "${nftPrefix}_mark_${mark} ${nftRuleParams} meta mark set (meta mark & ${fw_maskXor}) | ${mark}"
+				nft add rule inet "$nftTable" "${nftPrefix}_mark_${mark} return"
 			fi
 
 			if [ "$ipv4_error" -eq '0' ] || [ "$ipv6_error" -eq '0' ]; then
@@ -2318,6 +2325,12 @@ interface_routing() {
 					fi
 					try ip -4 rule replace fwmark "${mark}/${fw_mask}" table "$tid" priority "$priority" || ipv4_error=1
 				fi
+			elif [ -n "$strict_enforcement" ]; then
+				ipv4_error=0
+				ip -4 rule flush table "$tid" >/dev/null 2>&1
+				ip -4 route flush table "$tid" >/dev/null 2>&1
+				try ip -4 route replace unreachable default table "$tid" || ipv4_error=1
+				try ip -4 rule replace fwmark "${mark}/${fw_mask}" table "$tid" priority "$priority" || ipv4_error=1
 			fi
 
 			if [ -n "$ipv6_enabled" ] && [ -n "$dev6" ]; then
@@ -2341,6 +2354,12 @@ interface_routing() {
 					fi
 					try ip -6 rule replace fwmark "${mark}/${fw_mask}" table "$tid" priority "$priority" || ipv6_error=1
 				fi
+			elif [ -n "$ipv6_enabled" ] && [ -n "$strict_enforcement" ]; then
+				ipv6_error=0
+				ip -6 rule flush table "$tid" >/dev/null 2>&1
+				ip -6 route flush table "$tid" >/dev/null 2>&1
+				try ip -6 route replace unreachable default table "$tid" || ipv6_error=1
+				try ip -6 rule replace fwmark "${mark}/${fw_mask}" table "$tid" priority "$priority" || ipv6_error=1
 			fi
 
 			if [ "$ipv4_error" -eq '0' ] || [ "$ipv6_error" -eq '0' ]; then


### PR DESCRIPTION
When a tunnel interface (e.g. WireGuard) is disabled or down, it has no network device (dev4 is empty). Previously, the nft mark chain was only created inside the `if [ -n "$dev4" ]` block, so policies referencing the interface's mark chain would cause nft validation to fail with a missing chain error, cascading into a full startup failure.

Two changes in interface_routing() for both create and reload_interface:

1. Move nft mark chain creation outside the dev4/dev6 conditionals so it is always created regardless of device state. This ensures policies can always reference the chain.

2. Add elif branches for strict_enforcement when no device exists, creating unreachable default routes and fwmark rules to prevent traffic leaks while allowing interface_routing to succeed.

https://claude.ai/code/session_01PPJzA7hoVTuQKCHUNp8pzk