### PR TITLE
pbr[1.2.2]: exclude empty rules

### DIFF
--- a/files/etc/init.d/pbr
+++ b/files/etc/init.d/pbr
@@ -2182,9 +2182,14 @@ policy_process() {
 					if str_contains "$filter_group_src_addr" 'ipv6' && str_contains "$filter_group_dest_addr" 'ipv4'; then
 							continue
 					fi
-					policy_routing "$name" "$interface" "$filtered_value_src_addr" "$src_port" "$filtered_value_dest_addr" "$dest_port" "$proto" "$chain" "$uid"
-					processed_value_src_addr="${processed_value_src_addr:+${processed_value_src_addr} }$filtered_value_src_addr"
-					processed_value_dest_addr="${processed_value_dest_addr:+${processed_value_dest_addr} }$filtered_value_dest_addr"
+					if [ -n "${filtered_value_src_addr}${filtered_value_dest_addr}${src_port}${dest_port}${proto}" ]; then
+						policy_routing "$name" "$interface" "$filtered_value_src_addr" "$src_port" "$filtered_value_dest_addr" "$dest_port" "$proto" "$chain" "$uid"
+						processed_value_src_addr="${processed_value_src_addr:+${processed_value_src_addr} }$filtered_value_src_addr"
+						processed_value_dest_addr="${processed_value_dest_addr:+${processed_value_dest_addr} }$filtered_value_dest_addr"
+					else
+						json add error 'errorPolicyNoSrcDest' "$name"
+						output_fail; return 1;
+					fi
 				fi
 			done
 		fi

--- a/files/etc/init.d/pbr
+++ b/files/etc/init.d/pbr
@@ -2788,10 +2788,10 @@ start_service() {
 	local i k
 
 	load_package_config "$param"
-	stop_forward
 	[ "$param" = 'on_boot' ] && pbrBootFlag=1 && return 0
 	json init
 	load_environment "${param:-on_start}" "$(load_validate_config)" || return 1
+	stop_forward
 
 	output "Processing environment (${param:-on_start}) "
 	if ! is_wan_up "$param"; then


### PR DESCRIPTION
An empty rule can cause a massive leak, this PR stops empty rules from being add