### PR TITLE
pbr-1.2.2: move DNS-Policies up in the firewall

### DIFF
--- a/files/etc/init.d/pbr
+++ b/files/etc/init.d/pbr
@@ -979,7 +979,7 @@ nft_file() {
 			done
 			echo "" >> "$nftTempFile"
 			# Add jump rules from fw4 chains to pbr chains
-			echo "add rule inet $nftTable dstnat jump ${nftPrefix}_dstnat" >> "$nftTempFile"
+			echo "insert rule inet $nftTable dstnat jump ${nftPrefix}_dstnat" >> "$nftTempFile"
 			echo "add rule inet $nftTable mangle_prerouting jump ${nftPrefix}_prerouting" >> "$nftTempFile"
 			echo "add rule inet $nftTable mangle_output jump ${nftPrefix}_output" >> "$nftTempFile"
 			echo "add rule inet $nftTable mangle_forward jump ${nftPrefix}_forward" >> "$nftTempFile"


### PR DESCRIPTION
By executing DNS policies first in the firewall make sure those take precedence over other DNS-hijacking rules