### PR TITLE
pbr-1.2.2: only restart DNSMasq if /var/run/pbr.dnsmasq is changed

### DIFF
--- a/files/etc/init.d/pbr
+++ b/files/etc/init.d/pbr
@@ -198,6 +198,7 @@ nft_fw4_dump=
 loadEnvironmentFlag=
 loadPackageConfigFlag=
 resolverWorkingFlag=
+resolverStoredHash=
 
 # shellcheck disable=SC1091
 . "${IPKG_INSTROOT}/lib/functions.sh"
@@ -1446,7 +1447,7 @@ resolver() {
 					[ "$resolverNewHash" != "$resolverStoredHash" ]
 				;;
 				store_hash)
-					[ -s "$packageDnsmasqFile" ] && resolverStoredHash="$(md5sum "$packageDnsmasqFile" | awk '{ print $1; }')"
+					[ -s "$packageDnsmasqFile" ] && resolverStoredHash="$(md5sum "$packageDnsmasqFile" | awk '{ print $1; }')" || resolverStoredHash=
 					return 0
 				;;
 				wait)
@@ -2801,7 +2802,7 @@ on_interface_reload() {
 
 start_service() {
 	local param="$1"
-	local resolverStoredHash resolverNewHash reloadedIface
+	local reloadedIface
 	local i k
 
 	[ "$param" = 'on_boot' ] && pbrBootFlag=1 && return 0
@@ -2880,6 +2881,7 @@ start_service() {
 
 	case $serviceStartTrigger in
 		on_interface_reload)
+			resolver 'store_hash'
 			output_okn
 			output 1 "Reloading Interface: $reloadedIface "
 			json_add_array 'gateways'


### PR DESCRIPTION
DNSMasq was restarting always, with this patch DNSMasq is only restarted if the config file (/var/run/pbr.dnsmasq) is actually changed