### PR TITLE
pbr_get_gateway6: fix fallback producing invalid `ip -6 route` commands

### DIFF
--- a/files/etc/init.d/pbr
+++ b/files/etc/init.d/pbr
@@ -271,7 +271,15 @@ pbr_get_gateway6() {
 	is_uplink4 "$iface" && iface="$uplink_interface6"
 	network_get_gateway6 gw "$iface" true
 	if [ -z "$gw" ] || [ "$gw" = '::/0' ] || [ "$gw" = '::0/0' ] || [ "$gw" = '::' ]; then
-		gw="$(ip -6 a list dev "$dev" 2>/dev/null | grep inet6 | grep 'scope global' | awk '{print $2}')"
+		# Prefer the actual default-route nexthop on this device (usually fe80::).
+		gw="$(ip -6 route show dev "$dev" 2>/dev/null | awk '$1=="default" {print $3; exit}')"
+		# Fall back to a link-local neighbor advertised as router.
+		[ -z "$gw" ] && gw="$(ip -6 neigh show dev "$dev" 2>/dev/null | awk '/^fe80:.*router/ {print $1; exit}')"
+		# Last resort: first global address on the device, with prefix length stripped.
+		# The previous `awk '{print $2}'` (no line limit, prefix kept) produced a
+		# multi-line string like "2804::a/64\n2804::b/128" which turned `ip -6 route
+		# replace default via "$gw6" ...` into invalid syntax and failed every run.
+		[ -z "$gw" ] && gw="$(ip -6 a list dev "$dev" 2>/dev/null | awk '/inet6 .* scope global/ {sub(/\/.*/,"",$2); print $2; exit}')"
 	fi
 	eval "$1"='$gw'
 }


### PR DESCRIPTION
Problem
-------
pbr_get_gateway6() uses two strategies to discover the IPv6 next-hop for an interface:

  1. network_get_gateway6 (from /lib/functions/network.sh, parses the ubus `network.interface.<iface> status` object).
  2. A shell fallback that greps the interface's own addresses when (1) returns nothing usable ('', '::', '::/0', '::0/0').

The fallback (old line 274) was:

    gw="$(ip -6 a list dev "$dev" 2>/dev/null \
          | grep inet6 | grep 'scope global' | awk '{print $2}')"

Two independent defects:

 a) `awk '{print $2}'` runs over every matching line. On any interface
    with more than one global address — e.g. a DHCPv6 IA_NA plus SLAAC,
    an IA_PD assignment, or multiple delegated prefixes — the output is
    a newline-separated list, not a single address.
 b) `$2` is `<addr>/<prefixlen>` (from `ip -6 a` formatting). The `/<n>`
    suffix is not valid syntax for `ip route ... via`.

`gw6` is consumed by callers like (init.d/pbr:2247):

    try ip -6 route replace default via "$gw6" dev "$dev6" \
        table "$tid" metric "$uplink_interface6_metric"

With a multi-line, prefix-suffixed value quoted into `via`, `ip` sees one positional arg containing embedded newlines and returns an error.

Observable consequences on a real multi-WAN box
-----------------------------------------------
Reproducer environment: OpenWrt 25.12.2, three WANs — two of which receive multiple global IPv6 addresses from their ISPs:

    tim-wan:  2804:214:11:278d:62be:b4ff:fe1a:5cb5/64
              2804:214:11:278d::1/128
    str-wan:  fd0e:9b01:f8d7:10:62be:b4ff:fe1a:5cb7/64
              2803:9810:70fd:f610:62be:b4ff:fe1a:5cb7/64
              fd0e:9b01:f8d7:10::802/128
              2803:9810:70fd:f610::802/128

pbr logged the following every single run:

  ERROR: Command failed: ip -6 route replace default via \
    2804:214:11:278d:62be:b4ff:fe1a:5cb5/64 2804:214:11:278d::1/128 \
    dev tim-wan table 259 metric 128
  ERROR: Command failed: ip -6 route replace default via \
    fd0e:9b01:f8d7:10:62be:b4ff:fe1a:5cb7/64 \
    2803:9810:70fd:f610:62be:b4ff:fe1a:5cb7/64 \
    fd0e:9b01:f8d7:10::802/128 2803:9810:70fd:f610::802/128 \
    dev str-wan table 260 metric 128

Because the failure happens inside the main route-installation loop and netifd hotplug re-triggers pbr on any interface event (including the RA-refresh of the kernel-managed default route, which fires every router-lifetime period), pbr effectively enters a permanent reload loop: every ~60–75s it flushes and rebuilds its fw4 nftables chains. Each rebuild briefly perturbs conntrack mark save/restore and any in-flight UDP masquerade state, which on this box manifested as second-scale audio drops on WebRTC calls (Meet / Teams / Jitsi) across every WAN. pbr logs show the loop clearly:

  10:46:25  pbr ERROR ...
  10:47:02  pbr ERROR ...   (+37s)
  10:47:58  pbr ERROR ...   (+56s)
  10:49:04  pbr ERROR ...   (+66s)
  ...

Setting pbr.config.ipv6_enabled=0 silences the error loop and stops the forwarding disruption — confirming pbr's v6 fallback as the trigger.

Fix
---
Replace the fallback with a three-step cascade that returns a usable next-hop address (never a prefixed or multi-valued string):

 1. `ip -6 route show dev <dev>`: pick up the kernel's own default-route nexthop on that device (this is the address from the ISP's RA, typically an fe80::). This is what we actually want as `via`.
 2. `ip -6 neigh show dev <dev>`: first link-local neighbor flagged `router` — covers the case where step 1 missed because no default route has been planted in the main table for this device yet but an RA has been received.
 3. First global address on the device with `/<prefixlen>` stripped. Not ideal (it is our own address, not a real upstream gateway), but at least syntactically valid so the resulting `ip route` command does not crash pbr into a reload loop. `awk … exit` guarantees single-line output.

network_get_gateway6 remains the primary path — this only touches the fallback and does not change behaviour on interfaces where ubus already provides a nexthop.

Verification on the reproducer box after the patch -------------------------------------------------- pbr error count over the following 90s window: 0 (was 1 every ~60s). pbr "started with gateways:" log line, before vs after:

  before: wan_tim/tim-wan/192.168.1.1/
          2804:214:11:278d:62be:b4ff:fe1a:5cb5/64 2804:214:11:278d::1/128
          wan_str/str-wan/192.168.1.1/
          fd0e:9b01:f8d7:10:62be:b4ff:fe1a:5cb7/64
          2803:9810:70fd:f610:62be:b4ff:fe1a:5cb7/64
          fd0e:9b01:f8d7:10::802/128 2803:9810:70fd:f610::802/128

  after:  wan_tim/tim-wan/192.168.1.1/fe80::1
          wan_str/str-wan/192.168.1.1/fe80::7624:9fff:fed2:bc12
          wan_vivo/vivo-wan/192.168.15.1/fe80::c23d:d9ff:fe38:9e28

Each interface resolves to the upstream router's link-local address, which is the correct `via` value for `ip -6 route replace default`.

Note on the LuCI status display
-------------------------------
The "Service Gateways" field in LuCI previously showed GUA-looking values for misconfigured interfaces because the buggy fallback returned the interface's own global address. After the fix it shows the actual next-hop (fe80::...). That is a display change, not a regression — the old values were wrong, and attempting to use them as `via` was what caused the error loop in the first place.