### PR TITLE
pbr-1.2.2: flush rt-tables on stop and small optimizations

### DIFF
--- a/files/etc/init.d/pbr
+++ b/files/etc/init.d/pbr
@@ -2334,7 +2334,7 @@ interface_routing() {
 						try ip -6 route replace unreachable default table "$tid" || ipv6_error=1
 					fi
 					try ip -6 rule replace fwmark "${mark}/${fw_mask}" table "$tid" priority "$priority" || ipv6_error=1
-				elif ip -o link show dev "$dev4" 2>/dev/null | grep -q POINTOPOINT; then
+				elif ip -o link show dev "$dev6" 2>/dev/null | grep -q POINTOPOINT; then
 					try ip -6 route replace default dev "$dev6" table "$tid" metric "$uplink_interface6_metric" || ipv6_error=1
 					try ip -6 rule replace fwmark "${mark}/${fw_mask}" table "$tid" priority "$priority" || ipv6_error=1
 				fi

--- a/files/etc/init.d/pbr
+++ b/files/etc/init.d/pbr
@@ -1202,7 +1202,11 @@ cleanup() {
 			rt_tables)
 				# shellcheck disable=SC2013
 				for i in $(grep -oh "${ipTablePrefix}_.*" "$rtTablesFile"); do
-					! is_netifd_table "$i" && sed -i "/${i}/d" "$rtTablesFile"
+					if ! is_netifd_table "$i";then
+						ip -4 route flush table "$i" >/dev/null 2>&1
+						ip -6 route flush table "$i" >/dev/null 2>&1
+						sed -i "/${i}/d" "$rtTablesFile"
+					fi
 				done
 				sync
 			;;
@@ -2298,13 +2302,13 @@ interface_routing() {
 				if [ -n "$gw4" ] || [ -n "$strict_enforcement" ]; then
 					if [ -n "$gw4" ]; then 
 						try ip -4 route replace default via "$gw4" dev "$dev4" table "$tid" || ipv4_error=1
-					elif ip address show dev "$dev4" 2>/dev/null | grep -q "POINTOPOINT"; then     # might need to set this rule as first to prevent rogue gateway detection for point-to-point links
+					elif ip -o link show dev "$dev4" 2>/dev/null | grep -q POINTOPOINT; then     # might need to set this rule as first to prevent rogue gateway detection for point-to-point links
 						try ip -4 route replace default dev "$dev4" table "$tid" || ipv4_error=1
 					else
 						try ip -4 route replace unreachable default table "$tid" || ipv4_error=1
 					fi
 					try ip -4 rule replace fwmark "${mark}/${fw_mask}" table "$tid" priority "$priority" || ipv4_error=1
-				elif ip address show dev "$dev4" 2>/dev/null | grep -q "POINTOPOINT"; then
+				elif ip -o link show dev "$dev4" 2>/dev/null | grep -q POINTOPOINT; then
 					try ip -4 route replace default dev "$dev4" table "$tid" || ipv4_error=1
 					try ip -4 rule replace fwmark "${mark}/${fw_mask}" table "$tid" priority "$priority" || ipv4_error=1
 				fi
@@ -2324,13 +2328,13 @@ interface_routing() {
 				if [ -n "$gw6" ] || [ -n "$strict_enforcement" ]; then
 					if [ -n "$gw6" ]; then 
 						try ip -6 route replace default via "$gw6" dev "$dev6" table "$tid" metric "$uplink_interface6_metric" || ipv6_error=1
-					elif ip address show dev "$dev6" 2>/dev/null | grep -q "POINTOPOINT"; then     # might need to set this rule as first to prevent rogue gateway detection for point-to-point links
+					elif ip -o link show dev "$dev6" 2>/dev/null | grep -q POINTOPOINT; then     # might need to set this rule as first to prevent rogue gateway detection for point-to-point links
 						try ip -6 route replace default dev "$dev6" table "$tid" metric "$uplink_interface6_metric" || ipv6_error=1
 					else
 						try ip -6 route replace unreachable default table "$tid" || ipv6_error=1
 					fi
 					try ip -6 rule replace fwmark "${mark}/${fw_mask}" table "$tid" priority "$priority" || ipv6_error=1
-				elif ip address show dev "$dev6" 2>/dev/null | grep -q "POINTOPOINT"; then
+				elif ip -o link show dev "$dev4" 2>/dev/null | grep -q POINTOPOINT; then
 					try ip -6 route replace default dev "$dev6" table "$tid" metric "$uplink_interface6_metric" || ipv6_error=1
 					try ip -6 rule replace fwmark "${mark}/${fw_mask}" table "$tid" priority "$priority" || ipv6_error=1
 				fi


### PR DESCRIPTION
On stop the routing tables are not flushed.
This patch should correct that

Also some small optimisations for querying if an interface is point-to-point

minor things so no hurry in implementing

Please let @copilot do its thing to check