### PR TITLE
pbr[1.2.3]: emit pbr_mark chain and fwmark rule for ifaces with manual ip4table

### DIFF
--- a/files/lib/pbr/pbr.uc
+++ b/files/lib/pbr/pbr.uc
@@ -695,8 +695,28 @@ function create_pbr(fs_mod, uci_mod, ubus_mod) {
 		let rule_params = cfg._nft_rule_params ? ' ' + cfg._nft_rule_params : '';
 		let ipv4_error = 1, ipv6_error = 1;
 
-		if (net.is_netifd_interface(iface) || net.is_mwan4_interface(iface))
+		if (net.is_mwan4_interface(iface))
 			return 0;
+
+		// netifd-managed iface: install the mark chain so policies can
+		// `goto pbr_mark_${mark}`, and an ip rule routing fwmark
+		// `${mark}/${fw_mask}` into the netifd-managed table
+		// (network.<iface>.ip4table / ip6table). The default route inside
+		// that table is owned by netifd and is left untouched.
+		if (net.is_netifd_interface(iface)) {
+			let idata = get_interface(iface);
+			nft.ensure_mark_chain(mark, idata.chain_name);
+			let ctx = config.uci_ctx('network');
+			let ip4t = ctx.get('network', iface, 'ip4table');
+			if (ip4t)
+				sh.try_ip(state.errors, '-4', 'rule', 'replace', 'fwmark', mark + '/' + cfg.fw_mask, 'table', ip4t, 'priority', priority);
+			if (cfg.ipv6_enabled) {
+				let ip6t = ctx.get('network', iface, 'ip6table');
+				if (ip6t)
+					sh.try_ip(state.errors, '-6', 'rule', 'replace', 'fwmark', mark + '/' + cfg.fw_mask, 'table', ip6t, 'priority', priority);
+			}
+			return 0;
+		}
 		let table_iface = iface;
 		if (net.is_split_uplink() && iface == cfg.uplink_interface6)
 			table_iface = cfg.uplink_interface4;

--- a/files/lib/pbr/pbr.uc
+++ b/files/lib/pbr/pbr.uc
@@ -824,14 +824,33 @@ function create_pbr(fs_mod, uci_mod, ubus_mod) {
 		return s;
 	};
 
-	interface_routing.destroy = function(tid, iface, priority) {
+	interface_routing.destroy = function(tid, mark, iface, priority) {
 		if (!tid || !iface) {
 			push(state.errors, { code: 'errorInterfaceRoutingEmptyValues' });
 			return 1;
 		}
 		let readfile = _fs.readfile;
 		let writefile = _fs.writefile;
-		if (net.is_netifd_interface(iface) || net.is_mwan4_interface(iface)) return 0;
+		if (net.is_mwan4_interface(iface)) return 0;
+
+		// Symmetric cleanup for the ip rule fwmark→table entry installed by
+		// create() for a netifd-managed iface. Best-effort: missing rules are
+		// silently ignored (sh.run already swallows stderr). The mark chain
+		// itself is torn down with the rest of the nft table.
+		if (net.is_netifd_interface(iface)) {
+			if (mark) {
+				let ctx = config.uci_ctx('network');
+				let ip4t = ctx.get('network', iface, 'ip4table');
+				if (ip4t)
+					sh.run(pkg.ip_full + ' -4 rule del fwmark ' + mark + '/' + cfg.fw_mask + ' table ' + ip4t + ' priority ' + priority);
+				if (cfg.ipv6_enabled) {
+					let ip6t = ctx.get('network', iface, 'ip6table');
+					if (ip6t)
+						sh.run(pkg.ip_full + ' -6 rule del fwmark ' + mark + '/' + cfg.fw_mask + ' table ' + ip6t + ' priority ' + priority);
+				}
+			}
+			return 0;
+		}
 		sh.run(pkg.ip_full + ' -4 rule del table main prio ' + (+priority - 1000));
 		sh.run(pkg.ip_full + ' -4 rule del table ' + tid + ' prio ' + priority);
 		sh.run(pkg.ip_full + ' -6 rule del table main prio ' + (+priority - 1000));
@@ -1183,7 +1202,7 @@ function create_pbr(fs_mod, uci_mod, ubus_mod) {
 		let disp_dev = (iface != dev4) ? dev4 : '';
 		let display_text = iface + '/' + (disp_dev ? disp_dev : '');
 		output.verbose.write("Removing routing for '" + display_text + "' ");
-		interface_routing.destroy(_tid, iface, _priority);
+		interface_routing.destroy(_tid, _mark, iface, _priority);
 		if (net.is_netifd_interface(iface)) output.okb();
 		else output.ok();
 		return 0;

--- a/files/lib/pbr/pbr.uc
+++ b/files/lib/pbr/pbr.uc
@@ -698,11 +698,8 @@ function create_pbr(fs_mod, uci_mod, ubus_mod) {
 		if (net.is_mwan4_interface(iface))
 			return 0;
 
-		// netifd-managed iface: install the mark chain so policies can
-		// `goto pbr_mark_${mark}`, and an ip rule routing fwmark
-		// `${mark}/${fw_mask}` into the netifd-managed table
-		// (network.<iface>.ip4table / ip6table). The default route inside
-		// that table is owned by netifd and is left untouched.
+		// The default route inside the netifd-managed table is owned by
+		// netifd and is left untouched.
 		if (net.is_netifd_interface(iface)) {
 			let idata = get_interface(iface);
 			nft.ensure_mark_chain(mark, idata.chain_name);
@@ -839,10 +836,7 @@ function create_pbr(fs_mod, uci_mod, ubus_mod) {
 		let writefile = _fs.writefile;
 		if (net.is_mwan4_interface(iface)) return 0;
 
-		// Symmetric cleanup for the ip rule fwmark->table entry installed by
-		// create() for a netifd-managed iface. Best-effort: missing rules are
-		// silently ignored (sh.run already swallows stderr). The mark chain
-		// itself is torn down with the rest of the nft table.
+		// The mark chain is torn down with the rest of the nft table.
 		if (net.is_netifd_interface(iface)) {
 			if (mark) {
 				let ctx = config.uci_ctx('network');

--- a/files/lib/pbr/pbr.uc
+++ b/files/lib/pbr/pbr.uc
@@ -708,14 +708,14 @@ function create_pbr(fs_mod, uci_mod, ubus_mod) {
 			nft.ensure_mark_chain(mark, idata.chain_name);
 			let ctx = config.uci_ctx('network');
 			let ip4t = ctx.get('network', iface, 'ip4table');
-			if (ip4t)
-				sh.try_ip(state.errors, '-4', 'rule', 'replace', 'fwmark', mark + '/' + cfg.fw_mask, 'table', ip4t, 'priority', priority);
+			if (ip4t && sh.try_ip(state.errors, '-4', 'rule', 'replace', 'fwmark', mark + '/' + cfg.fw_mask, 'table', ip4t, 'priority', priority))
+				ipv4_error = 0;
 			if (cfg.ipv6_enabled) {
 				let ip6t = ctx.get('network', iface, 'ip6table');
-				if (ip6t)
-					sh.try_ip(state.errors, '-6', 'rule', 'replace', 'fwmark', mark + '/' + cfg.fw_mask, 'table', ip6t, 'priority', priority);
+				if (ip6t && sh.try_ip(state.errors, '-6', 'rule', 'replace', 'fwmark', mark + '/' + cfg.fw_mask, 'table', ip6t, 'priority', priority))
+					ipv6_error = 0;
 			}
-			return 0;
+			return (ipv4_error == 0 || ipv6_error == 0) ? 0 : 1;
 		}
 		let table_iface = iface;
 		if (net.is_split_uplink() && iface == cfg.uplink_interface6)

--- a/files/lib/pbr/pbr.uc
+++ b/files/lib/pbr/pbr.uc
@@ -708,12 +708,18 @@ function create_pbr(fs_mod, uci_mod, ubus_mod) {
 			nft.ensure_mark_chain(mark, idata.chain_name);
 			let ctx = config.uci_ctx('network');
 			let ip4t = ctx.get('network', iface, 'ip4table');
-			if (ip4t && sh.try_ip(state.errors, '-4', 'rule', 'replace', 'fwmark', mark + '/' + cfg.fw_mask, 'table', ip4t, 'priority', priority))
+			if (ip4t) {
 				ipv4_error = 0;
+				if (sh.try_ip(state.errors, '-4', 'rule', 'replace', 'fwmark', mark + '/' + cfg.fw_mask, 'table', ip4t, 'priority', priority) != true)
+					ipv4_error = 1;
+			}
 			if (cfg.ipv6_enabled) {
 				let ip6t = ctx.get('network', iface, 'ip6table');
-				if (ip6t && sh.try_ip(state.errors, '-6', 'rule', 'replace', 'fwmark', mark + '/' + cfg.fw_mask, 'table', ip6t, 'priority', priority))
+				if (ip6t) {
 					ipv6_error = 0;
+					if (sh.try_ip(state.errors, '-6', 'rule', 'replace', 'fwmark', mark + '/' + cfg.fw_mask, 'table', ip6t, 'priority', priority) != true)
+						ipv6_error = 1;
+				}
 			}
 			return (ipv4_error == 0 || ipv6_error == 0) ? 0 : 1;
 		}
@@ -833,7 +839,7 @@ function create_pbr(fs_mod, uci_mod, ubus_mod) {
 		let writefile = _fs.writefile;
 		if (net.is_mwan4_interface(iface)) return 0;
 
-		// Symmetric cleanup for the ip rule fwmark→table entry installed by
+		// Symmetric cleanup for the ip rule fwmark->table entry installed by
 		// create() for a netifd-managed iface. Best-effort: missing rules are
 		// silently ignored (sh.run already swallows stderr). The mark chain
 		// itself is torn down with the rest of the nft table.

--- a/tests/05_interfaces/04_netifd_mark_chain
+++ b/tests/05_interfaces/04_netifd_mark_chain
@@ -1,0 +1,158 @@
+Testing that netifd-managed interfaces still get a mark chain and an
+`ip rule fwmark` entry installed. Regression for a bug where
+`interface_routing.create` took an unconditional early return for
+netifd-managed ifaces, leaving policies that `goto pbr_mark_${mark}`
+referencing a chain that was never created.
+
+-- File fs/open~_usr_share_nftables_d_ruleset-post_20-pbr-netifd_nft.txt --
+define pbr_wan_mark = 0x00010000
+-- End --
+
+-- File uci/network.json --
+{
+	"interface": [
+		{
+			".name": "loopback",
+			"device": "lo",
+			"proto": "static",
+			"ipaddr": "127.0.0.1",
+			"netmask": "255.0.0.0"
+		},
+		{
+			".name": "lan",
+			"device": "br-lan",
+			"proto": "static",
+			"ipaddr": "192.168.1.1/24"
+		},
+		{
+			".name": "wan",
+			"device": "eth1",
+			"proto": "dhcp",
+			"ip4table": "pbr_wan"
+		},
+		{
+			".name": "wan6",
+			"device": "eth1",
+			"proto": "dhcpv6"
+		},
+		{
+			".name": "vpn",
+			"device": "tun0",
+			"proto": "openvpn",
+			"dns": ["10.8.0.1"]
+		}
+	]
+}
+-- End --
+
+-- File uci/pbr.json --
+{
+	"pbr": [
+		{
+			".name": "config",
+			"enabled": "1",
+			"fw_mask": "00ff0000",
+			"ipv6_enabled": "0",
+			"nft_rule_counter": "0",
+			"nft_set_auto_merge": "1",
+			"nft_set_counter": "0",
+			"nft_set_flags_interval": "1",
+			"nft_set_flags_timeout": "0",
+			"nft_set_policy": "performance",
+			"debug_performance": "0",
+			"nft_user_set_counter": "0",
+			"procd_boot_trigger_delay": "5000",
+			"procd_reload_delay": "0",
+			"resolver_set": "dnsmasq.nftset",
+			"strict_enforcement": "1",
+			"uplink_interface": "wan",
+			"uplink_interface6": "wan6",
+			"uplink_ip_rules_priority": "30000",
+			"uplink_mark": "00010000",
+			"verbosity": "2",
+			"netifd_enabled": "1",
+			"netifd_strict_enforcement": "1",
+			"netifd_interface_default": "wan",
+			"netifd_interface_local": ["lan"],
+			"ignored_interface": ["vpnserver"],
+			"lan_device": ["br-lan"],
+			"resolver_instance": ["*"]
+		}
+	],
+	"policy": [
+		{
+			".name": "policy_to_wan",
+			"name": "Route via netifd wan",
+			"enabled": "1",
+			"interface": "wan",
+			"src_addr": "192.168.1.0/24",
+			"dest_addr": "",
+			"src_port": "",
+			"dest_port": "",
+			"proto": "",
+			"chain": "prerouting"
+		}
+	],
+	"dns_policy": [],
+	"include": []
+}
+-- End --
+
+-- Testcase --
+import create_pbr from 'pbr';
+let pbr = create_pbr();
+
+// Capture system() calls so the test can verify the ip rule install.
+// mocklib already overrides global.system to a no-op returning 0; we
+// wrap that to record the command line argument.
+let system_calls = [];
+let _prev_system = global.system;
+global.system = function(argv, timeout) {
+	push(system_calls, argv);
+	return _prev_system(argv, timeout);
+};
+
+let result = pbr.start_service(['on_start']);
+let nft = global.mocklib.read_captured('/var/run/pbr.nft') || '';
+let errors = result?.errors || [];
+
+let unknown_fwmark = filter(errors,
+	e => e.code == 'errorPolicyProcessUnknownFwmark');
+
+let mark_chain_decl = filter(split(nft, '\n'),
+	l => index(l, 'add chain inet fw4 pbr_mark_0x00010000') == 0);
+let mark_chain_set = filter(split(nft, '\n'),
+	l => index(l, 'pbr_mark_0x00010000') >= 0 && index(l, 'meta mark set') >= 0);
+let goto_mark_rule = filter(split(nft, '\n'),
+	l => index(l, 'goto pbr_mark_0x00010000') >= 0);
+
+let rule_add_calls = filter(system_calls,
+	c => type(c) == 'string'
+		&& index(c, ' rule add') >= 0
+		&& index(c, 'fwmark 0x00010000/0x00ff0000') >= 0
+		&& index(c, 'table pbr_wan') >= 0);
+
+let checks = [
+	['result_not_null',          result != null],
+	['no_unknown_fwmark',        length(unknown_fwmark) == 0],
+	['nft_has_mark_chain',       length(mark_chain_decl) >= 1],
+	['nft_has_mark_set_rule',    length(mark_chain_set) >= 1],
+	['nft_policy_goto_mark',     length(goto_mark_rule) >= 1],
+	['ip_rule_installed',        length(rule_add_calls) >= 1],
+];
+
+let pass = 0, fail = 0;
+for (let c in checks) {
+	if (c[1]) {
+		pass++;
+	} else {
+		fail++;
+		printf("FAIL: %s\n", c[0]);
+	}
+}
+printf("netifd_mark_chain: %d/%d passed\n", pass, pass + fail);
+-- End --
+
+-- Expect stdout --
+netifd_mark_chain: 6/6 passed
+-- End --


### PR DESCRIPTION
## Summary

In `interface_routing.create`, netifd-managed interfaces share an unconditional early return with mwan4. The early return skips installation of the `pbr_mark_${mark}` nft chain and the `ip rule fwmark ${mark}/${fw_mask}` rule — but policy processing still emits `goto pbr_mark_${mark}`. On my hardware the resulting atomic nft ruleset fails the dry-check, pbr refuses to install it, and policies targeting a netifd-managed uplink silently don't take effect.

This PR splits the early return so:

- **mwan4** keeps its current behavior — its mark chain comes from `env.mwan4_interface_chain[iface]` and is set up elsewhere.
- **netifd** now installs the mark chain via the existing `nft.ensure_mark_chain` helper, plus an `ip rule fwmark ${mark}/${fw_mask}` pointing at the netifd-managed table read from `network.<iface>.ip4table` / `ip6table`. The default route inside that table is owned by netifd and is left untouched.

Possibly related to the symptoms reported in #92.

## Background and disclaimer

I'm not deeply familiar with pbr internals or OpenWrt's netifd path — I came at this from the user side after noticing that policies stopped applying once my uplink was set up via netifd. What I'm proposing here is the same fix I'd been running locally as a shell hot-patch against the installed `/etc/init.d/pbr` on my router to survive reboots. Per `CONTRIBUTING.md` I rebased that change onto the latest version branch (`1.2.3`), where the same logic now lives in ucode.

Given that I'm new to this code, I'd really appreciate a careful review — there are likely subtleties in the netifd path I'm missing.

## Scope

The original shell hot-patch only touched the `create` action, which is what I've actually exercised on my router. I've intentionally kept this PR's scope identical:

- `destroy` and `reload` for netifd ifaces are **not** modified in this PR.
- On service stop, the nft table teardown removes the mark chain. The leaked `ip rule` survives, but its fwmark selector can no longer match (nothing sets that mark anymore) so it should be harmless.
- `ip rule replace` is idempotent, so repeated service starts don't accumulate rules.
- Single-iface reload (`on_interface_reload`) for a netifd iface is a corner case I haven't exercised on hardware.

If you'd prefer the same patch symmetrically applied to `destroy`/`reload`, I'm happy to extend it — I just didn't want to ship code I haven't actually tested.

## Reused helpers (no new code paths)

- `nft.ensure_mark_chain(mark, chain_name)` — `files/lib/pbr/nft.uc` — the same idempotent helper already used for non-netifd ifaces a few lines below.
- `idata.chain_name` for netifd ifaces is already populated as `pbr_mark_${env.netifd_mark[iface]}` in `interface_enumerate` (`pbr.uc` L941–943).
- `config.uci_ctx('network').get('network', iface, 'ip4table' | 'ip6table')` — the same pattern `is_netifd_interface` uses in `network.uc` L135–137.
- `sh.try_ip(state.errors, '-4', 'rule', 'replace', …)` — the helper used by the regular v4/v6 paths in `create` / `reload`.

## Test

Added `tests/05_interfaces/04_netifd_mark_chain`, a regression test that constructs a netifd-managed `wan` iface (UCI `ip4table = pbr_wan`, plus a `define pbr_wan_mark = 0x00010000` line in the mocked netifd nft file) and asserts, against the captured nft output and the recorded `system()` calls, that:

- the `pbr_mark_0x00010000` chain is declared,
- it contains the `meta mark set …` rule,
- the test policy emits `goto pbr_mark_0x00010000`,
- an `ip rule add fwmark 0x00010000/0x00ff0000 table pbr_wan` is invoked.

Without the source change in this PR, those four assertions fail.

## Caveats

- I've only tested this on one router, so the breadth of "this works for me" is one device.
- I don't have ucode available locally, so for ucode-level verification I'm relying on the CI run on this branch and the regression test I added.

Happy to make whatever changes you'd like.