### PR TITLE
pbr[1.2.3]: tighten is_netifd_interface() to require env.netifd_mark

### DIFF
--- a/files/lib/pbr/network.uc
+++ b/files/lib/pbr/network.uc
@@ -132,10 +132,7 @@ function create_network(fs_mod, config, sh, pkg, platform, V) {
 	function is_ignore_target(iface) { return lc(iface) == 'ignore'; }
 	function is_netifd_table(name) { let c = readfile('/etc/config/network') || ''; return index(c, name) >= 0 && !!match(c, regexp('ip.table.*' + name)); }
 	function is_netifd_interface(iface) {
-		let ctx = config.uci_ctx('network');
-		let ip4t = ctx.get('network', iface, 'ip4table');
-		let ip6t = ctx.get('network', iface, 'ip6table');
-		return !!(ip4t || ip6t);
+		return !!(iface && env.netifd_mark[iface]);
 	}
 	function is_mwan4_interface(iface) {
 		return !!(iface && env.mwan4_mark[iface]);


### PR DESCRIPTION
Re-take of #104 along the direction @stangri proposed in https://github.com/mossdef-org/pbr/pull/104#issuecomment-4430726271 — instead of adding a netifd-specific branch to `interface_routing.create`, tighten `is_netifd_interface()` itself.

`is_netifd_interface()` previously classified by UCI alone (any iface with `ip4table` or `ip6table` set), which over-included user-manual two-uplink setups that pbr did not put in place. In dynamic-routing-tables mode this caused `interface_routing 'create'` to early-return for such ifaces, leaving the per-mark chain and `ip rule fwmark` uninstalled while policy processing still emitted `goto pbr_mark_${mark}` — the resulting ruleset failed `nft -c -f` and pbr aborted on start.

The helper is now narrowed to ifaces present in `env.netifd_mark`, populated from `pkg.nft_netifd_file` — i.e. ifaces pbr itself set up via its netifd extensions. The check now mirrors `is_mwan4_interface()`'s `env.mwan4_mark[iface]`.

One subtle side effect: user-manual `ip4table` ifaces are now added to `ifaces_triggers`, so pbr reloads on their dev up/down — the intended behaviour once pbr does manage them.
