### PR TITLE
Fix missing per-interface procd triggers causing routing failures on interface bouce

### DIFF
--- a/files/etc/init.d/pbr
+++ b/files/etc/init.d/pbr
@@ -59,19 +59,24 @@ start_service() {
 	[ "$param" = 'on_boot' ] && return 0
 	trap 'enable_forward' EXIT
 	stop_forward
-	# Call ucode to do all work; it returns json_add_* shell commands
-	# shellcheck disable=SC2034
-	_procd_svc_data="$($_ucode start_service "$param" "$2")"
+	local _pbr_svc_defs
+	_pbr_svc_defs="$($_ucode start_service "$param" "$2")"
 	# shellcheck disable=SC2181
 	[ $? -eq 0 ] || return 1
-	if [ -z "$_procd_svc_data" ]; then
+	if [ -z "$_pbr_svc_defs" ]; then
 		# ucode returned no procd data (e.g. uplink not ready);
 		# set boot flag so service_triggers registers interface.*.up retry
 		[ ! -s "/var/run/${packageName}.lock" ] && touch "/var/run/${packageName}.boot"
 		return 0
 	fi
+	# ucode emits two top-level variable assignments:
+	#   _pbr_ifaces_triggers — space-separated iface list, consumed by service_triggers()
+	#   _pbr_svc_data        — json_add_* command block, eval'd by service_data()
+	# Both must be set here (before procd invokes service_triggers) so the
+	# trigger registration sees the iface list.
+	eval "$_pbr_svc_defs"
 }
-service_data() { [ -n "$_procd_svc_data" ] && eval "$_procd_svc_data"; }
+service_data() { eval "$_pbr_svc_data"; }
 stop_service() { $_ucode stop_service; }
 reload_service() { rc_procd start_service 'on_reload'; }
 restart_service() {
@@ -114,11 +119,9 @@ service_triggers() {
 			procd_add_config_trigger "config.change" 'openvpn' "/etc/init.d/${packageName}" reload 'on_openvpn_change'
 			procd_add_config_trigger "config.change" "${packageName}" "/etc/init.d/${packageName}" reload
 			procd_add_config_trigger "config.change" "network" "/etc/init.d/${packageName}" reload
-			if [ -n "$_pbr_ifaces_triggers" ]; then
-				for n in $_pbr_ifaces_triggers; do
-					procd_add_interface_trigger "interface.*" "$n" "/etc/init.d/${packageName}" on_interface_reload "$n"
-				done
-			fi
+			for n in $_pbr_ifaces_triggers; do
+				procd_add_interface_trigger "interface.*" "$n" "/etc/init.d/${packageName}" on_interface_reload "$n"
+			done
 		procd_close_trigger
 	fi
 }

--- a/files/lib/pbr/pbr.uc
+++ b/files/lib/pbr/pbr.uc
@@ -1953,7 +1953,13 @@ function create_pbr(fs_mod, uci_mod, ubus_mod) {
 	}
 	
 	// ── emit_procd_shell ────────────────────────────────────────────────
-	
+
+	// Package the procd data into two top-level shell variable assignments
+	// consumed by init.d/pbr:
+	//   _pbr_ifaces_triggers — space-separated list of netifd ifaces that
+	//                          need per-interface procd triggers
+	//   _pbr_svc_data        — multi-line string of json_add_* commands
+	//                          that populate procd's service_data block
 	function emit_procd_shell(data) {
 		if (!data) return '';
 		let lines = [];
@@ -2014,13 +2020,12 @@ function create_pbr(fs_mod, uci_mod, ubus_mod) {
 			push(lines, 'json_close_object');
 		}
 		push(lines, 'json_close_array');
-	
-		if (data.ifacesTriggers)
-			push(lines, '_pbr_ifaces_triggers=' + sh.quote(data.ifacesTriggers));
-	
-		return join('\n', lines) + '\n';
+
+		let body = join('\n', lines);
+		return '_pbr_ifaces_triggers=' + sh.quote(data.ifacesTriggers || '') + '\n' +
+		       '_pbr_svc_data='        + sh.quote(body) + '\n';
 	}
-	
+
 	// ── Status Service ──────────────────────────────────────────────────
 	
 	function status_service(params) {

--- a/tests/03_nft_rules/01_emit_procd_shell
+++ b/tests/03_nft_rules/01_emit_procd_shell
@@ -31,13 +31,13 @@ let shell_output = pbr.emit_procd_shell(data);
 
 // Verify key shell commands are present
 let checks = [
-	['has_compat',       index(shell_output, "json_add_int packageCompat '26'") >= 0],
+	['has_compat',       index(shell_output, "json_add_int packageCompat '\\''26'\\''") >= 0],
 	['has_gateways_arr', index(shell_output, 'json_add_array gateways') >= 0],
-	['has_wan_name',     index(shell_output, "json_add_string name 'wan'") >= 0],
-	['has_gateway_ip',   index(shell_output, "json_add_string gateway_ipv4 '203.0.113.1'") >= 0],
+	['has_wan_name',     index(shell_output, "json_add_string name '\\''wan'\\''") >= 0],
+	['has_gateway_ip',   index(shell_output, "json_add_string gateway_ipv4 '\\''203.0.113.1'\\''") >= 0],
 	['has_default_bool', index(shell_output, 'json_add_boolean default') >= 0],
 	['has_status_obj',   index(shell_output, 'json_add_object status') >= 0],
-	['has_gw_string',    index(shell_output, "json_add_string gateways 'wan/eth1/203.0.113.1'") >= 0],
+	['has_gw_string',    index(shell_output, "json_add_string gateways '\\''wan/eth1/203.0.113.1'\\''") >= 0],
 	['has_errors_arr',   index(shell_output, 'json_add_array errors') >= 0],
 	['has_warnings_arr', index(shell_output, 'json_add_array warnings') >= 0],
 ];

--- a/tests/03_nft_rules/02_emit_procd_shell_errors
+++ b/tests/03_nft_rules/02_emit_procd_shell_errors
@@ -21,10 +21,10 @@ let data = {
 let shell_output = pbr.emit_procd_shell(data);
 
 let checks = [
-	['has_error_code_1',  index(shell_output, "json_add_string code 'errorNoGateways'") >= 0],
-	['has_error_code_2',  index(shell_output, "json_add_string code 'errorConfigValidation'") >= 0],
-	['has_error_info',    index(shell_output, "json_add_string info '/etc/config/pbr'") >= 0],
-	['has_warning_code',  index(shell_output, "json_add_string code 'warningUplinkDown'") >= 0],
+	['has_error_code_1',  index(shell_output, "json_add_string code '\\''errorNoGateways'\\''") >= 0],
+	['has_error_code_2',  index(shell_output, "json_add_string code '\\''errorConfigValidation'\\''") >= 0],
+	['has_error_info',    index(shell_output, "json_add_string info '\\''/etc/config/pbr'\\''") >= 0],
+	['has_warning_code',  index(shell_output, "json_add_string code '\\''warningUplinkDown'\\''") >= 0],
 ];
 
 let pass = 0, fail = 0;


### PR DESCRIPTION
I noticed after some time my wireguard interfaces ended up with no default route:

```
ip route show table pbr_vpn
```

It appears that if for whatever reason the interface ends up `ifdown`/`ifup` the default-route that PBR added is lost. Restarting pbr fully fixed the problem.

It appeared that PBR was failing to register procd interface triggers for these interfaces (This could be seen in `ubus call service list '{"name":"pbr","verbose":true}' | grep 'interface.*'`

The cause was the fact `files/etc/init.d/pbr`'s `service_triggers()` function relied on `_pbr_ifaces_triggers` but that was not populated until `service_data()` was called which was after `service_triggers()`.

Fixed by making `ucode start_service` return two things, a blob for service_data and a blob for service_triggers.

AI Disclosure: Code Written by Claude Opus, Reviewed and Tested by me.