### PR TITLE
pbr-1.2.2: guard pbr_get_gateway6 when ipv6 is disabled

### DIFF
--- a/files/etc/init.d/pbr
+++ b/files/etc/init.d/pbr
@@ -273,6 +273,7 @@ pbr_get_gateway4() {
 	eval "$1"='$gw'
 }
 pbr_get_gateway6() {
+	[ -z "$ipv6_enabled" ] && return 0
 	local iface="$2" dev="$3" gw
 	is_uplink4 "$iface" && iface="$uplink_interface6"
 	network_get_gateway6 gw "$iface" true


### PR DESCRIPTION
Even if IPv6 is disabled pbr_get_gateway6 is called. 
Disable this by guarding with ipv6_enabled check 
This can prevent an error when a broadcast interface has no IPv6.