### PR TITLE
pbr-1.2.2: correct multiple dns source entries

### DIFF
--- a/files/etc/init.d/pbr
+++ b/files/etc/init.d/pbr
@@ -2115,15 +2115,17 @@ dns_policy_process() {
 	dest_dns_ipv4="$(str_first_value_ipv4 "$dest_dns")"
 	dest_dns_ipv6="$(str_first_value_ipv6 "$dest_dns")"
 	if is_supported_interface "$dest_dns_interface"; then
-		local d
+		local d s
 		for d in $(uci -q get network."$dest_dns_interface".dns); do
-			if ! is_family_mismatch "$src_addr" "$d"; then
-				if is_ipv4 "$d"; then
-					dest_dns_ipv4="${dest_dns_ipv4:-${d}}"
-				elif is_ipv6 "$d"; then
-					dest_dns_ipv6="${dest_dns_ipv6:-${d}}"
+			for s in $src_addr; do
+				if ! is_family_mismatch "$s" "$d"; then
+					if is_ipv4 "$d"; then
+						dest_dns_ipv4="${dest_dns_ipv4:-${d}}"
+					elif is_ipv6 "$d"; then
+						dest_dns_ipv6="${dest_dns_ipv6:-${d}}"
+					fi
 				fi
-			fi
+			done
 		done
 	fi
 


### PR DESCRIPTION
Thanks to @AndrewZ : https://forum.openwrt.org/t/policy-based-routing-pbr-package-discussion/140639/2801?u=egc

Multiple MAC entries in DNS source rule were generating an error because the whole line was evaluated

Correct by evaluating each entry in the source