### PR TITLE
pbr-1.2.2: dnsmasq, set overlapping domains on the same set

### DIFF
--- a/files/etc/init.d/pbr
+++ b/files/etc/init.d/pbr
@@ -1113,8 +1113,26 @@ nftset() {
 		;;
 		add_dnsmasq_element)
 			[ -n "$ipv6_enabled" ] || unset nftset6
-			grep -qxF "nftset=/${param}/4#inet#${nftTable}#${nftset4}${nftset6:+,6#inet#${nftTable}#${nftset6}} # $comment" "$packageDnsmasqFile" && return 0
-			echo "nftset=/${param}/4#inet#${nftTable}#${nftset4}${nftset6:+,6#inet#${nftTable}#${nftset6}} # $comment" >> "$packageDnsmasqFile" && ipv4_error=0
+			local new_spec="4#inet#${nftTable}#${nftset4}${nftset6:+,6#inet#${nftTable}#${nftset6}}"
+			local escaped_param
+			escaped_param=$(printf '%s' "$param" | sed 's/\./\\./g')
+			local safe_nftset4 safe_nftset6
+			safe_nftset4=$(printf '%s' "$nftset4" | sed 's|[/.^$*\[\\]|\\&|g')
+			safe_nftset6=$(printf '%s' "${nftset6:-}" | sed 's|[/.^$*\[\\]|\\&|g')
+			grep -qE "^nftset=/${escaped_param}/.*#${safe_nftset4}(,| |$)" "$packageDnsmasqFile" && return 0
+			if grep -q "^nftset=/${escaped_param}/" "$packageDnsmasqFile"; then
+				local append_spec="$new_spec"
+				if [ -n "$nftset6" ] && grep -qE "^nftset=/${escaped_param}/.*#${safe_nftset6}(,| |$)" "$packageDnsmasqFile"; then
+					append_spec="4#inet#${nftTable}#${nftset4}"
+				fi
+				local safe_append_spec safe_comment
+				safe_append_spec=$(printf '%s' "$append_spec" | sed 's|[|&\\]|\\&|g')
+				safe_comment=$(printf '%s' "$comment" | sed 's|[|&\\]|\\&|g')
+				sed -i "/^nftset=\/${escaped_param}\// s|\( #.*\)$|,${safe_append_spec}\1, ${safe_comment}|" \
+					"$packageDnsmasqFile" && ipv4_error=0
+			else
+				echo "nftset=/${param}/${new_spec} # ${comment}" >> "$packageDnsmasqFile" && ipv4_error=0
+			fi
 		;;
 		create)
 			case "$type" in

--- a/files/etc/init.d/pbr
+++ b/files/etc/init.d/pbr
@@ -1126,8 +1126,8 @@ nftset() {
 					append_spec="4#inet#${nftTable}#${nftset4}"
 				fi
 				local safe_append_spec safe_comment
-				safe_append_spec=$(printf '%s' "$append_spec" | sed 's|[|&\\]|\\&|g')
-				safe_comment=$(printf '%s' "$comment" | sed 's|[|&\\]|\\&|g')
+				safe_append_spec=$(printf '%s' "$append_spec" | sed 's/[|&\\]/\\&/g')
+				safe_comment=$(printf '%s' "$comment" | sed 's/[|&\\]/\\&/g')
 				sed -i "/^nftset=\/${escaped_param}\// s|\( #.*\)$|,${safe_append_spec}\1, ${safe_comment}|" \
 					"$packageDnsmasqFile" && ipv4_error=0
 			else


### PR DESCRIPTION
DNSMasq only resolves the first nftset it encounters. When using sets with overlapping domains not all sets are filled.

This patch should solve this but needs testing and reviewing, not ready for immediate implementation

Thanks to @alex-di-96 : mossdef-org#112

I have set it as draft because I want first see how 1.2.3-r67 and 1.2.2-r16 are working out before adding this. Furthermore it is not a serious problem and not a real bug, it is more a workaround for a DNSMasq problem.

Also it might need some more work. I have been testing it but lets see what co-pilot thinks of it

I have made some changes according to co-pilot's suggestions lets see what co-pilot thinks of it