### PR TITLE
pbr-1.2.2: version bump

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=pbr
 PKG_VERSION:=1.2.2
-PKG_RELEASE:=16
+PKG_RELEASE:=17
 PKG_LICENSE:=AGPL-3.0-or-later
 PKG_MAINTAINER:=Stan Grishin <stangri@melmac.ca>
 


### PR DESCRIPTION
This release adds:
Better gateway handling
Allow the same domain in multiple nftsets thanks to @alex-di-96