### PR TITLE
pbr-1.2.2: add bypass for wan6 dhcp renew when gateway is not changed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=pbr
 PKG_VERSION:=1.2.2
-PKG_RELEASE:=16
+PKG_RELEASE:=17
 PKG_LICENSE:=AGPL-3.0-or-later
 PKG_MAINTAINER:=Stan Grishin <stangri@melmac.ca>
 

--- a/files/etc/init.d/pbr
+++ b/files/etc/init.d/pbr
@@ -2872,7 +2872,6 @@ start_service() {
 	load_package_config "$param"
 
 	trap 'enable_forward' EXIT
-	stop_forward
 
 	load_environment "${param:-on_start}" "$(load_validate_config)" || return 1
 	output "Processing environment (${param:-on_start}) "
@@ -2892,6 +2891,7 @@ start_service() {
 		pbrBootFlag=1
 		return 0
 	fi
+	output_okn
 
 	case "$param" in
 		on_boot)
@@ -2941,6 +2941,20 @@ start_service() {
 		serviceStartTrigger="${serviceStartTrigger:-on_start}"
 	fi
 
+	# skip on_interface_reload of wan6 in case of renew of DHCP with no change in gateway
+	if [ "$serviceStartTrigger" = 'on_interface_reload' ] && is_uplink6 "$reloadedIface"; then
+		local prevGwIpv6
+		prevGwIpv6="$(ubus_get_interface "$reloadedIface" 'gateway_ipv6')"
+		output 2 "on_interface_reload '$reloadedIface': current IPv6 gateway='${uplinkGW6:-<empty>}', previous='${prevGwIpv6:-<empty>}'\n"
+		if [ -n "$uplinkGW6" ] && [ "$uplinkGW6" = "$prevGwIpv6" ]; then
+			output 2 "Skipping reload for '$reloadedIface': IPv6 gateway unchanged\n"
+			resolver 'store_hash'
+			return 0
+		fi
+	fi
+
+	stop_forward
+
 	procd_open_instance 'main'
 	procd_set_param command /bin/true
 	procd_set_param stdout 1
@@ -2950,7 +2964,6 @@ start_service() {
 	case $serviceStartTrigger in
 		on_interface_reload)
 			resolver 'store_hash'
-			output_okn
 			output 1 "Reloading Interface: $reloadedIface "
 			json_add_array 'gateways'
 			process_interface 'all' 'reset_globals'
@@ -2963,7 +2976,6 @@ start_service() {
 			resolver 'configure'
 			cleanup 'main_table' 'rt_tables' 'main_chains' 'sets'
 			nft_file 'create' 'main'
-			output_okn
 			output 1 'Processing interfaces '
 			json_add_array 'gateways'
 			process_interface 'all' 'reset_globals'


### PR DESCRIPTION
    DHCP renew for wan6 can trigger an interface event on some setups.
    Skip this when the gateway is not changed.
    
    For clean skip `stop_forward` was moved, some output_okn was replaced and
    dnsmasq store hash was taken into account
    
    Signed-off-by: Erik Conijn <egc112@msn.com>