### PR TITLE
keep forwarding during interface reload

### DIFF
--- a/files/etc/init.d/pbr
+++ b/files/etc/init.d/pbr
@@ -58,8 +58,10 @@ boot() {
 start_service() {
 	local param="${1:-on_start}"
 	[ "$param" = 'on_boot' ] && return 0
-	trap 'enable_forward' EXIT
-	stop_forward
+	if [ "$param" != 'on_interface_reload' ]; then
+		trap 'enable_forward' EXIT
+		stop_forward
+	fi
 	local _pbr_svc_defs
 	_pbr_svc_defs="$($_ucode start_service "$param" "$2")"
 	# shellcheck disable=SC2181


### PR DESCRIPTION
## Summary

This avoids disabling forwarding for `on_interface_reload` starts.

Full service starts, reloads, and restarts keep the existing `stop_forward` / `enable_forward` behavior. Only targeted interface reloads skip the forwarding toggle.

## Motivation

On a router with several IPv6 WANs, normal RA/DHCPv6 refreshes can trigger frequent `interface.*` events. In my case, `wan_str6` advertises short public IPv6 and prefix lifetimes of roughly 3-5 minutes, and `wan_vivo6` has an RA default route lifetime around 3 minutes.

Those events cause repeated PBR `on_interface_reload` runs. Because the init wrapper disables forwarding before calling the ucode start logic, each targeted interface reload briefly interrupts LAN forwarding. The user-visible symptom was streaming traffic, especially YouTube, playing for a while, freezing for tens of seconds, then resuming, repeatedly.

The selected policy path was healthy: YouTube was routed through `wan_tim`, not the noisy `wan_str6` path. The interruption correlated with repeated PBR interface reloads rather than WAN packet loss.

## Router observations

Environment where reproduced:

- OpenWrt 25.12.x
- nft/fw4 mode
- PBR with IPv6 enabled
- Multiple WAN interfaces: `wan_vivo`, `wan_tim`, `wan_str`, plus IPv6 peers
- YouTube policy targets `wan_tim`
- Frequent `Processing environment (on_interface_reload)` logs from IPv6 RA/DHCPv6 refreshes

Examples from the router:

```text
pbr ... Processing environment (on_interface_reload) ... wan_vivo6 ... wan_str6 ... wan_tim6 ...
```

`ubus monitor` showed `network.interface notify_proto` updates for IPv6 interfaces such as `wan_vivo6` and `wan_str6` shortly before PBR reloads.

`wan_tim` was stable during testing:

```text
120 packets transmitted, 120 packets received, 0% packet loss
round-trip min/avg/max = 26.868/27.270/27.895 ms
```

## Validation

I tested the same logic on the affected router before opening this PR.

Validation performed:

- Deployed equivalent runtime change to `/etc/init.d/pbr`
- Ran `ash -n /etc/init.d/pbr`
- Triggered `/etc/init.d/pbr on_interface_reload wan_str6`
- Confirmed `/proc/sys/net/ipv4/ip_forward` stayed `1`
- Monitored natural IPv6-triggered PBR interface reloads for 90 seconds
- Confirmed `ip_forward` stayed `1` throughout repeated `on_interface_reload` events
- Verified YouTube policy routing still selected `wan_tim` for IPv4 and IPv6
- Verified a YouTube probe over `tim-wan` returned HTTP `204`

Representative route checks after the change:

```text
142.250.219.46 via 192.168.1.1 dev tim-wan table pbr_wan_tim src 192.168.1.2 mark 0x40000
2804:214:800f:68::9 via fe80::1 dev tim-wan table pbr_wan_tim
```

## Notes

This is intentionally minimal. The init wrapper currently disables forwarding before the ucode start logic resolves whether a reload remains a targeted `on_interface_reload` or falls back to a full start. This patch uses the init command parameter as the guard, so the common targeted interface-reload path avoids the forwarding interruption while full reload/restart paths remain unchanged.

If you prefer the guard to use the resolved ucode `service_start_trigger`, I can follow up with a slightly larger refactor where ucode exposes that decision before the forwarding toggle.
