### PR TITLE
pbr-1.2.2: change display of missing gateways

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=pbr
 PKG_VERSION:=1.2.2
-PKG_RELEASE:=19
+PKG_RELEASE:=20
 PKG_LICENSE:=AGPL-3.0-or-later
 PKG_MAINTAINER:=Stan Grishin <stangri@melmac.ca>
 

--- a/files/etc/init.d/pbr
+++ b/files/etc/init.d/pbr
@@ -37,7 +37,7 @@ fi
 
 readonly packageName='pbr'
 readonly PKG_VERSION='dev-test'
-readonly packageCompat='26'
+readonly packageCompat='27'
 readonly serviceName="$packageName $PKG_VERSION"
 readonly packageConfigFile="/etc/config/${packageName}"
 readonly packageDebugFile="/var/run/${packageName}.debug"
@@ -2647,8 +2647,11 @@ process_interface() {
 			pbr_get_gateway6 gw6 "$iface" "$dev6"
 			pbr_get_ipaddr4 ipa4 "$iface" "$dev4"
 			pbr_get_ipaddr6 ipa6 "$iface" "$dev6"
-			dispGw4="${gw4:-${ipa4:--}}"
-			dispGw6="${gw6:-${ipa6:--}}"
+			dispGw4="${gw4:-${ipa4:-0.0.0.0}}"
+			case "${gw6:-$ipa6}" in
+				''|'::'|'::0'|'::/0'|'::0/0') dispGw6='::0' ;;
+				*) dispGw6="${gw6:-$ipa6}" ;;
+			esac
 			if is_split_uplink; then
 				if is_uplink4 "$iface"; then
 					gw6=""; dev6=""
@@ -2738,8 +2741,11 @@ process_interface() {
 			pbr_get_gateway6 gw6 "$iface" "$dev6"
 			pbr_get_ipaddr4 ipa4 "$iface" "$dev4"
 			pbr_get_ipaddr6 ipa6 "$iface" "$dev6"
-			dispGw4="${gw4:-${ipa4:--}}"
-			dispGw6="${gw6:-${ipa6:--}}"
+			dispGw4="${gw4:-${ipa4:-0.0.0.0}}"
+			case "${gw6:-$ipa6}" in
+				''|'::'|'::0'|'::/0'|'::0/0') dispGw6='::0' ;;
+				*) dispGw6="${gw6:-$ipa6}" ;;
+			esac
 			if is_split_uplink; then
 				if is_uplink4 "$iface"; then
 					gw6=""; dev6=""
@@ -2769,8 +2775,11 @@ process_interface() {
 			pbr_get_gateway6 gw6 "$iface" "$dev6"
 			pbr_get_ipaddr4 ipa4 "$iface" "$dev4"
 			pbr_get_ipaddr6 ipa6 "$iface" "$dev6"
-			dispGw4="${gw4:-${ipa4:--}}"
-			dispGw6="${gw6:-${ipa6:--}}"
+			dispGw4="${gw4:-${ipa4:-0.0.0.0}}"
+			case "${gw6:-$ipa6}" in
+				''|'::'|'::0'|'::/0'|'::0/0') dispGw6='::0' ;;
+				*) dispGw6="${gw6:-$ipa6}" ;;
+			esac
 			if is_split_uplink; then
 				if is_uplink4 "$iface"; then
 					gw6=""; dev6=""


### PR DESCRIPTION
Instead of a hyphen -, 0.0.0.0 and ::0 are shown when an IPv4/IPv6 gateway is missing.

Bumped release version to 20 and compat version to 27, to bring in line with LuCi changes