### PR TITLE
pbr-1.2.3: fix deferred boot race condition by passing state via arguments

### DIFF
--- a/files/etc/init.d/pbr
+++ b/files/etc/init.d/pbr
@@ -104,7 +104,7 @@ service_started() {
 	[ "$1" = 'on_boot' ] && return 0
 	enable_forward
 	trap - EXIT
-	$_ucode service_started "$1"
+	$_ucode service_started "$1" "$_pbr_deferred_to_boot"
 }
 service_triggers() {
 	local procd_boot_trigger_delay procd_reload_delay n boot_mode=

--- a/files/lib/pbr/cli.uc
+++ b/files/lib/pbr/cli.uc
@@ -41,7 +41,7 @@ case 'version':
 	break;
 
 case 'service_started':
-	pbr.service_started(ARGV[0]);
+	pbr.service_started(ARGV[0], ARGV[1]);
 	break;
 
 case 'should_skip_reload':

--- a/files/lib/pbr/pbr.uc
+++ b/files/lib/pbr/pbr.uc
@@ -1980,12 +1980,14 @@ function create_pbr(fs_mod, uci_mod, ubus_mod) {
 	
 	// ── service_started ─────────────────────────────────────────────────
 	
-	function service_started(param) {
+	function service_started(param, deferred_to_boot) {
 		if (param == 'on_boot') return;
 		// Uplink was down at start time; we've already emitted the warning
 		// and are waiting for the procd boot trigger to retry. This is a
 		// designed deferral, not a startup failure.
-		if (_deferred_to_boot) return;
+		if (deferred_to_boot == '1' || _deferred_to_boot) {
+			return;
+		}
 
 		load_platform();
 

--- a/tests/05_interfaces/04_uplink_down_no_failed_to_start
+++ b/tests/05_interfaces/04_uplink_down_no_failed_to_start
@@ -55,7 +55,12 @@ global.system = function(argv, timeout) {
 };
 
 let result = pbr.start_service(['on_start']);
-pbr.service_started('on_start');
+
+// OpenWrt rc.common wrapper runs service_started in a NEW ucode process,
+// making it stateless. The wrapper bridges this gap by passing the
+// deferred boot state as the second argument.
+let pbr2 = create_pbr();
+pbr2.service_started('on_start', result?.deferredToBoot ? '1' : '');
 
 let failed_to_start = filter(system_calls,
 	c => type(c) == 'string' && index(c, 'FAILED TO START') >= 0);

--- a/tests/05_interfaces/09_deferred_boot_no_lock
+++ b/tests/05_interfaces/09_deferred_boot_no_lock
@@ -1,0 +1,67 @@
+Testing that when the uplink is down at start time, service_started does not write the lock file, and does not print FAILED TO START.
+
+-- File ubus/network.interface.wan~status.json --
+{
+	"up": false,
+	"pending": false,
+	"available": true,
+	"autostart": true,
+	"dynamic": false,
+	"uptime": 0,
+	"l3_device": "eth1",
+	"device": "eth1",
+	"proto": "dhcp",
+	"ipv4-address": [],
+	"route": [],
+	"dns-server": []
+}
+-- End --
+
+-- File ubus/network.interface.wan6~status.json --
+{
+	"up": false,
+	"pending": false,
+	"available": true,
+	"autostart": true,
+	"dynamic": false,
+	"uptime": 0,
+	"l3_device": "eth1",
+	"device": "eth1",
+	"proto": "dhcpv6",
+	"ipv6-address": [],
+	"route": []
+}
+-- End --
+
+-- Testcase --
+import create_pbr from 'pbr';
+let pbr = create_pbr();
+
+let result = pbr.start_service(['on_start']);
+
+// The wrapper script now passes deferred_to_boot='1' instead of relying on pbr.boot
+
+// Call service_started with deferred_to_boot='1' just like init.d/pbr now does
+pbr.service_started('on_start', '1');
+
+let checks = [
+	['start_service_returns_partial', type(result) == 'object'],
+	['deferred_to_boot_set',          result?.deferredToBoot == true],
+	['no_lock_file_created',          !global.mocklib.has_captured('/var/run/pbr.lock')],
+];
+
+let pass = 0, fail = 0;
+for (let c in checks) {
+	if (c[1]) {
+		pass++;
+	} else {
+		fail++;
+		printf("FAIL: %s\n", c[0]);
+	}
+}
+printf("deferred_boot_no_lock: %d/%d passed\n", pass, pass + fail);
+-- End --
+
+-- Expect stdout --
+deferred_boot_no_lock: 3/3 passed
+-- End --

--- a/tests/05_interfaces/10_normal_boot_creates_lock
+++ b/tests/05_interfaces/10_normal_boot_creates_lock
@@ -1,0 +1,34 @@
+Testing that when the uplink is UP at start time, service_started writes the lock file.
+
+-- Testcase --
+import create_pbr from 'pbr';
+let pbr = create_pbr();
+
+let result = pbr.start_service(['on_start']);
+
+// Simulate the wrapper script deleting pbr.boot if it existed
+global.mocklib.delete_captured('/var/run/pbr.boot');
+
+// normal service started
+pbr.service_started('on_start');
+
+let checks = [
+	['start_service_returns_full',    result?.deferredToBoot != true],
+	['lock_file_created',             global.mocklib.has_captured('/var/run/pbr.lock')],
+];
+
+let pass = 0, fail = 0;
+for (let c in checks) {
+	if (c[1]) {
+		pass++;
+	} else {
+		fail++;
+		printf("FAIL: %s\n", c[0]);
+	}
+}
+printf("normal_boot_creates_lock: %d/%d passed\n", pass, pass + fail);
+-- End --
+
+-- Expect stdout --
+normal_boot_creates_lock: 2/2 passed
+-- End --

--- a/tests/05_interfaces/11_reload_degraded_upgrades_to_start
+++ b/tests/05_interfaces/11_reload_degraded_upgrades_to_start
@@ -1,0 +1,83 @@
+Testing that if on_interface_reload is triggered but PBR hasn't successfully completed a full start (no gateways in service data), it processes all interfaces when service data is empty.
+
+-- File ubus/service~list~name-pbr.json --
+{
+	"pbr": {
+		"data": {
+		}
+	}
+}
+-- End --
+
+-- File fs/popen~nft_list_table_inet_fw4_2_dev_null.txt --
+table inet fw4 {
+	chain pbr_mark_0x010000 { }
+}
+-- End --
+
+-- File uci/network.json --
+{
+	"interface": [
+		{
+			".name": "wan",
+			"device": "eth1",
+			"proto": "dhcp"
+		},
+		{
+			".name": "wg0",
+			"proto": "wireguard"
+		}
+	]
+}
+-- End --
+
+-- File uci/pbr.json --
+{
+	"pbr": [
+		{
+			".name": "config",
+			"enabled": "1",
+			"uplink_interface": "wan",
+			"verbosity": "2"
+		}
+	]
+}
+-- End --
+
+-- Testcase --
+import create_pbr from 'pbr';
+let pbr = create_pbr();
+
+// wg0 is live
+let orig_read_json = global.mocklib.read_json_file;
+global.mocklib.read_json_file = function(path) {
+	if (path == 'ubus/network.interface.wg0~status.json') {
+		return { up: true, l3_device: "wg0-live", device: "wg0-live", proto: "wireguard" };
+	}
+	return orig_read_json(path);
+};
+
+// We trigger a reload of 'wan', but because PBR data is empty,
+// it processes all interfaces. Thus it will ALSO build routes
+// for 'wg0'. If it were a partial reload, wg0 would be skipped
+// and gw.action would be 'skip_interface' or it wouldn't even
+// appear if not in the cached registry.
+let result = pbr.start_service(['on_interface_reload', 'wan']);
+
+let checks = [];
+let wg0_gw = filter(result.gateways, g => g.name == 'wg0')[0];
+
+push(checks, ['wg0_processed', wg0_gw != null]);
+push(checks, ['wg0_action_create', wg0_gw?.action == 'create']);
+push(checks, ['wg0_dev4_populated', wg0_gw?.device_ipv4 == 'wg0-live']);
+
+let pass = 0, fail = 0;
+for (let c in checks) {
+	if (c[1]) pass++; else { fail++; printf("FAIL: %s\n", c[0]); }
+}
+printf("reload_degraded_upgrades_to_start: %d/%d passed\n", pass, pass + fail);
+-- End --
+
+-- Expect stdout --
+reload_degraded_upgrades_to_start: 3/3 passed
+-- End --

--- a/tests/06_shell_wrapper/01_deferred_boot_lifecycle.sh
+++ b/tests/06_shell_wrapper/01_deferred_boot_lifecycle.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+
+TEST_DIR="$(mktemp -d)"
+trap 'rm -rf "$TEST_DIR"' EXIT
+
+# Create mock ucode binary to intercept calls
+cat << EOF > "$TEST_DIR/mock_ucode"
+#!/bin/bash
+# Shift away the -S -L arguments if they exist
+while [[ "\$1" == -* ]]; do
+    if [ "\$1" = "-L" ]; then shift 2; else shift; fi
+done
+cmd="\$1"
+param="\$2"
+arg_passed="\$3"
+
+if [ "\$cmd" = "start_service" ]; then
+    echo "_pbr_deferred_to_boot=1"
+    exit 0
+elif [ "\$cmd" = "service_started" ]; then
+    if [ "\$arg_passed" = "1" ]; then
+        echo "PASS_VIA_ARGUMENT" > "$TEST_DIR/test_result"
+    elif [ -f "$TEST_DIR/var_run/pbr.boot" ]; then
+        echo "PASS_VIA_FILE" > "$TEST_DIR/test_result"
+    else
+        echo "FAIL_MISSING_STATE" > "$TEST_DIR/test_result"
+        touch "$TEST_DIR/var_run/pbr.lock"
+    fi
+    exit 0
+fi
+EOF
+chmod +x "$TEST_DIR/mock_ucode"
+
+mkdir -p "$TEST_DIR/var_run"
+echo "FAIL_UNSET" > "$TEST_DIR/test_result"
+
+# Copy and patch init.d/pbr to use our isolated directories and mocked ucode
+cp files/etc/init.d/pbr "$TEST_DIR/pbr_mock.sh"
+sed -i "s|/var/run|$TEST_DIR/var_run|g" "$TEST_DIR/pbr_mock.sh"
+sed -i "s|readonly _ucode=.*|readonly _ucode=\"$TEST_DIR/mock_ucode\"|g" "$TEST_DIR/pbr_mock.sh"
+
+# Remove OpenWrt source lines to prevent errors
+sed -i 's|^\. /lib/functions.sh|# . /lib/functions.sh|' "$TEST_DIR/pbr_mock.sh"
+sed -i 's|^\. /lib/functions/network.sh|# . /lib/functions/network.sh|' "$TEST_DIR/pbr_mock.sh"
+sed -i 's|^\. "${IPKG_INSTROOT}/usr/share/libubox/jshn.sh"|# . /usr/share/libubox/jshn.sh|' "$TEST_DIR/pbr_mock.sh"
+
+(
+    # Mock OpenWrt rc.common environment
+    rc_procd() {
+        "$@"
+        if type service_triggers >/dev/null 2>&1; then
+            service_triggers
+        fi
+    }
+    config_load() { :; }
+    config_get() { eval "$1=\"$4\""; }
+    config_get_bool() { eval "$1=\"$4\""; }
+    procd_add_raw_trigger() { return 0; }
+    stop_forward() { :; }
+    enable_forward() { :; }
+    procd_open_validate() { :; }
+    procd_close_validate() { :; }
+    procd_open_trigger() { :; }
+    procd_close_trigger() { :; }
+    procd_add_config_trigger() { :; }
+    uci_load_validate() { :; }
+
+    start() {
+        rc_procd start_service "$@"
+        if type service_started >/dev/null 2>&1; then
+            service_started "$@"
+        fi
+    }
+
+    # Source the patched init.d script
+    . "$TEST_DIR/pbr_mock.sh"
+
+    # Execute the boot lifecycle natively
+    start "on_start"
+)
+
+RESULT=$(cat "$TEST_DIR/test_result")
+if [ "$RESULT" = "PASS_VIA_ARGUMENT" ]; then
+    exit 0
+else
+    echo "Expected PASS_VIA_ARGUMENT, but got: $RESULT" >&2
+    exit 1
+fi

--- a/tests/06_shell_wrapper/02_boot_fast_path.sh
+++ b/tests/06_shell_wrapper/02_boot_fast_path.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+TEST_DIR="$(mktemp -d)"
+trap 'rm -rf "$TEST_DIR"' EXIT
+
+cat << EOF > "$TEST_DIR/mock_ucode"
+#!/bin/bash
+# If mock_ucode is called during boot(), it's a FAILURE because boot() should bypass ucode completely!
+echo "YES" > "$TEST_DIR/ucode_called"
+exit 1
+EOF
+chmod +x "$TEST_DIR/mock_ucode"
+
+mkdir -p "$TEST_DIR/var_run"
+echo "NO" > "$TEST_DIR/ucode_called"
+echo "NO" > "$TEST_DIR/trigger_added"
+
+cp files/etc/init.d/pbr "$TEST_DIR/pbr_mock.sh"
+sed -i "s|/var/run|$TEST_DIR/var_run|g" "$TEST_DIR/pbr_mock.sh"
+sed -i "s|readonly _ucode=.*|readonly _ucode=\"$TEST_DIR/mock_ucode\"|g" "$TEST_DIR/pbr_mock.sh"
+
+sed -i 's|^\. /lib/functions.sh|# . /lib/functions.sh|' "$TEST_DIR/pbr_mock.sh"
+sed -i 's|^\. /lib/functions/network.sh|# . /lib/functions/network.sh|' "$TEST_DIR/pbr_mock.sh"
+sed -i 's|^\. "${IPKG_INSTROOT}/usr/share/libubox/jshn.sh"|# . /usr/share/libubox/jshn.sh|' "$TEST_DIR/pbr_mock.sh"
+
+(
+    rc_procd() {
+        "$@"
+        if type service_triggers >/dev/null 2>&1; then
+            service_triggers
+        fi
+    }
+    config_load() { :; }
+    config_get() { eval "$1=\"$4\""; }
+    config_get_bool() { eval "$1=1"; } # enabled=1
+    procd_add_raw_trigger() {
+        if [ "$1" = "interface.*.up" ]; then
+            echo "YES" > "$TEST_DIR/trigger_added"
+        fi
+        return 0
+    }
+    procd_add_config_trigger() { :; }
+    procd_add_interface_trigger() { :; }
+    procd_open_validate() { :; }
+    procd_close_validate() { :; }
+    procd_open_trigger() { :; }
+    procd_close_trigger() { :; }
+    uci_load_validate() { :; }
+    stop_forward() { :; }
+    enable_forward() { :; }
+
+    . "$TEST_DIR/pbr_mock.sh"
+    boot
+)
+
+UCODE_CALLED="$(cat "$TEST_DIR/ucode_called")"
+TRIGGER_ADDED="$(cat "$TEST_DIR/trigger_added")"
+
+if [ "$UCODE_CALLED" = "YES" ]; then
+    echo "FAIL: ucode was called during boot!" >&2
+    exit 1
+fi
+if [ "$TRIGGER_ADDED" = "NO" ]; then
+    echo "FAIL: interface.*.up trigger was not added!" >&2
+    exit 1
+fi
+if [ -f "$TEST_DIR/var_run/pbr.boot" ]; then
+    echo "FAIL: pbr.boot file was left on disk (not cleaned up by service_triggers)!" >&2
+    exit 1
+fi
+
+exit 0

--- a/tests/06_shell_wrapper/03_service_data_unset.sh
+++ b/tests/06_shell_wrapper/03_service_data_unset.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+TEST_DIR="$(mktemp -d)"
+trap 'rm -rf "$TEST_DIR"' EXIT
+
+cat << EOF > "$TEST_DIR/mock_ucode"
+#!/bin/bash
+echo "_pbr_svc_data=''"
+exit 0
+EOF
+chmod +x "$TEST_DIR/mock_ucode"
+
+cp files/etc/init.d/pbr "$TEST_DIR/pbr_mock.sh"
+sed -i "s|readonly _ucode=.*|readonly _ucode=\"$TEST_DIR/mock_ucode\"|g" "$TEST_DIR/pbr_mock.sh"
+sed -i 's|^\. /lib/functions.sh|# . /lib/functions.sh|' "$TEST_DIR/pbr_mock.sh"
+sed -i 's|^\. /lib/functions/network.sh|# . /lib/functions/network.sh|' "$TEST_DIR/pbr_mock.sh"
+sed -i 's|^\. "${IPKG_INSTROOT}/usr/share/libubox/jshn.sh"|# . /usr/share/libubox/jshn.sh|' "$TEST_DIR/pbr_mock.sh"
+
+(
+    stop_forward() { :; }
+    enable_forward() { :; }
+
+    . "$TEST_DIR/pbr_mock.sh"
+
+    if ! type service_data >/dev/null 2>&1; then
+        echo "FAIL: service_data not found initially!" > "$TEST_DIR/result"
+        exit 1
+    fi
+
+    start_service "on_start"
+
+    if type service_data >/dev/null 2>&1; then
+        echo "FAIL: service_data was NOT unset!" > "$TEST_DIR/result"
+        exit 1
+    fi
+
+    echo "PASS" > "$TEST_DIR/result"
+) >/dev/null 2>&1
+
+if [ "$(cat "$TEST_DIR/result")" = "PASS" ]; then
+    exit 0
+else
+    cat "$TEST_DIR/result" >&2
+    exit 1
+fi

--- a/tests/06_shell_wrapper/04_on_interface_reload_gatekeeper.sh
+++ b/tests/06_shell_wrapper/04_on_interface_reload_gatekeeper.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+TEST_DIR="$(mktemp -d)"
+trap 'rm -rf "$TEST_DIR"' EXIT
+
+cat << EOF > "$TEST_DIR/mock_ucode"
+#!/bin/bash
+echo "\$1" >> "$TEST_DIR/ucode_calls"
+if [ "\$1" = "should_skip_reload" ]; then
+    exit 0 # return 0 so it skips reload, simplifies the test
+fi
+exit 0
+EOF
+chmod +x "$TEST_DIR/mock_ucode"
+
+mkdir -p "$TEST_DIR/var_run"
+touch "$TEST_DIR/ucode_calls"
+
+cp files/etc/init.d/pbr "$TEST_DIR/pbr_mock.sh"
+sed -i "s|/var/run|$TEST_DIR/var_run|g" "$TEST_DIR/pbr_mock.sh"
+sed -i "s|readonly _ucode=.*|readonly _ucode=\"$TEST_DIR/mock_ucode\"|g" "$TEST_DIR/pbr_mock.sh"
+sed -i 's|^\. /lib/functions.sh|# . /lib/functions.sh|' "$TEST_DIR/pbr_mock.sh"
+sed -i 's|^\. /lib/functions/network.sh|# . /lib/functions/network.sh|' "$TEST_DIR/pbr_mock.sh"
+sed -i 's|^\. "${IPKG_INSTROOT}/usr/share/libubox/jshn.sh"|# . /usr/share/libubox/jshn.sh|' "$TEST_DIR/pbr_mock.sh"
+
+(
+    rc_procd() { :; }
+    stop_forward() { :; }
+    enable_forward() { :; }
+
+    . "$TEST_DIR/pbr_mock.sh"
+
+    # Test 1: No lock file
+    if on_interface_reload "wg0"; then
+        echo "FAIL: Should have returned 1 when lock missing!" > "$TEST_DIR/result"
+        exit 1
+    fi
+    if [ -s "$TEST_DIR/ucode_calls" ]; then
+        echo "FAIL: ucode was called despite missing lock!" > "$TEST_DIR/result"
+        exit 1
+    fi
+
+    # Test 2: With lock file
+    touch "$TEST_DIR/var_run/pbr.lock"
+    if ! on_interface_reload "wg0"; then
+        echo "FAIL: Should have returned 0!" > "$TEST_DIR/result"
+        exit 1
+    fi
+    if ! grep -q "should_skip_reload" "$TEST_DIR/ucode_calls"; then
+        echo "FAIL: ucode should_skip_reload was not called!" > "$TEST_DIR/result"
+        exit 1
+    fi
+
+    echo "PASS" > "$TEST_DIR/result"
+) >/dev/null 2>&1
+
+if [ "$(cat "$TEST_DIR/result")" = "PASS" ]; then
+    exit 0
+else
+    cat "$TEST_DIR/result" >&2
+    exit 1
+fi

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -275,16 +275,16 @@ run_test() {
 n_tests=0
 n_fails=0
 
-select_tests="$@"
+select_tests=("$@")
 
 use_test() {
 	local input="$(readlink -f "$1")"
 	local test
 
 	[ -f "$input" ] || return 1
-	[ -n "$select_tests" ] || return 0
+	[ ${#select_tests[@]} -gt 0 ] || return 0
 
-	for test in "$select_tests"; do
+	for test in "${select_tests[@]}"; do
 		test="$(readlink -f "$test")"
 
 		[ "$test" != "$input" ] || return 0
@@ -302,6 +302,20 @@ for catdir in tests/[0-9][0-9]_*; do
 		use_test "$testfile" || continue
 
 		n_tests=$((n_tests + 1))
+		
+		if [ "${testfile##*.}" = "sh" ]; then
+			name=${testfile##*/}
+			printf "%s %s " "$name" "${line:${#name}}"
+			if bash "$testfile" >/dev/null 2>&1; then
+				printf "OK\n"
+			else
+				printf "FAILED\n"
+				bash "$testfile" # run again to show output
+				n_fails=$((n_fails + 1))
+			fi
+			continue
+		fi
+
 		run_test "$testfile" || n_fails=$((n_fails + 1))
 	done
 done


### PR DESCRIPTION
When the uplink is down at startup, start_service defers to boot mode. The wrapper writes `/var/run/pbr.boot` so that service_triggers can register a boot-retry trigger. However, service_started spawns a new ucode process that does not inherit the in-memory `_deferred_to_boot` flag, so it incorrectly treats the deferral as a startup failure and emits FAILED TO START.

Previously, the `.boot` marker file was used to bridge this gap, however service_triggers deletes it before service_started runs (both are called sequentially by rc.common in the same shell process).

Fix this by passing `$_pbr_deferred_to_boot` directly as the second argument to `$_ucode service_started`, into pbr.service_started(), managing this state in the shell process instead.

Changed test `05_interfaces/04_uplink_down_no_failed_to_start` to use a separate `create_pbr()` instance for service_started, matching the real two-process lifecycle, and update it to pass state via arguments. 

Also added a test case simulating the rc.common shell-script boot lifecycle `06_shell_wrapper`.

Also added several other tests covering different parts of the boot process that I looked at while trying to diagnose this problem. None of these tests failed but are probably useful to have in future.