### PR TITLE
pbr-1.2.3: show output when skipping reloading interface

### DIFF
--- a/files/lib/pbr/pbr.uc
+++ b/files/lib/pbr/pbr.uc
@@ -1700,6 +1700,7 @@ function create_pbr(fs_mod, uci_mod, ubus_mod) {
 			// value is process-local, so this is effectively a no-op here, kept
 			// for parity with the reference implementation.
 			nft.resolver.store_hash();
+			output.print('pbr: skipping reload for ' + iface + ' - IPv6 gateway unchanged (' + cur + ')\n');
 			return true;
 		}
 		return false;

--- a/files/lib/pbr/pbr.uc
+++ b/files/lib/pbr/pbr.uc
@@ -1700,7 +1700,7 @@ function create_pbr(fs_mod, uci_mod, ubus_mod) {
 			// value is process-local, so this is effectively a no-op here, kept
 			// for parity with the reference implementation.
 			nft.resolver.store_hash();
-			output.print('pbr: skipping reload for ' + iface + ' - IPv6 gateway unchanged (' + cur + ')\n');
+			output.verbose.write("Skipping reload for '" + iface + "' - IPv6 gateway unchanged (" + cur + ")\\n");
 			return true;
 		}
 		return false;


### PR DESCRIPTION
Show output when wan6 interface reload is skipped.

This is more a feature request from me and can be discarded if you do not like it.