### PR TITLE
pbr-1.2.3: show output for enable_forward

### DIFF
--- a/files/lib/pbr/pbr.uc
+++ b/files/lib/pbr/pbr.uc
@@ -131,6 +131,7 @@ function create_pbr(fs_mod, uci_mod, ubus_mod) {
 		output.okn();
 	};
 	forwarding.enable = function() {
+		load_config();
 		if (forwarding._read() != '1') {
 			sh.run('/sbin/sysctl -w net.ipv4.ip_forward=1');
 			sh.run('/sbin/sysctl -w net.ipv6.conf.all.forwarding=1');


### PR DESCRIPTION
when invoking enable_forward no output is shown although it seems to work.

The problem seems that the config is not loaded in pbr.forwarding.enable. This means output's internal state is still at its uninitialized default state

Adding `load_config();` should solve this.