### PR TITLE
pbr-1.2.3: refactor restart()

### DIFF
--- a/files/etc/init.d/pbr
+++ b/files/etc/init.d/pbr
@@ -91,13 +91,13 @@ start_service() {
 service_data() { eval "$_pbr_svc_data"; }
 stop_service() { $_ucode stop_service; }
 reload_service() { rc_procd start_service 'on_reload'; }
-restart_service() {
+restart() {
 	trap 'enable_forward' EXIT
 	stop_forward
 	stop
 	# it takes time before routes are cleaned up, if started immediately a leak can occur
 	[ "$(cat /proc/sys/net/ipv4/ip_forward)" = "0" ] && sleep 2
-	rc_procd start_service 'on_restart'
+	start
 }
 status_service() { $_ucode status_service "$@"; }
 service_started() {


### PR DESCRIPTION
`restart_service` is not working at all, however when doing a `service pbr restart` automatically a `stop` and `start` is done which does indeed trigger a restart. 
But this will cause leakage as forwarding is not stopped  on `stop` We need a separate `restart ()` just as in 1.2.2 with proper stopping of forwarding at the start of the `restart ()` function to block leakage of traffic