### PR TITLE
pbr-1.2.3: show missing ipv6 gateway

### DIFF
--- a/files/lib/pbr/pbr.uc
+++ b/files/lib/pbr/pbr.uc
@@ -1083,13 +1083,12 @@ function create_pbr(fs_mod, uci_mod, ubus_mod) {
 		return 0;
 	};
 
-	// Build the "GW4[/GW6]" display suffix. IPv4 always renders (falling back
-	// to 0.0.0.0); the IPv6 segment is omitted entirely when the interface has
-	// no v6 gateway or address, so v6-less interfaces don't render a bare "/-".
+	// Build the "GW4[/GW6]" display suffix. IPv4 falls back to 0.0.0.0,
+	// IPv6 to ::0 ; the IPv6 segment is omitted when IPv6 is disabled
 	function disp_gw_suffix(dg4, dg6) {
 		let s = dg4 || '0.0.0.0';
-		if (cfg.ipv6_enabled && dg6 && dg6 != '')
-			s += '/' + dg6;
+		if (cfg.ipv6_enabled)
+			s += '/' + (dg6 || '::0');
 		return s;
 	}
 


### PR DESCRIPTION
For IPv4 a missing gateway is already shown as 0.0.0.0. 
For a missing IPv6 gateway nothing is shown.
A missing gateway, missing when there is no gateway and the interface is not a point-to-point link, signals a potential problem with the interface/device so has value showing it.

An IPv6 gateway, missing or otherwise, is only shown when IPv6 is enabled.

This patch enables the showing of a missing IPv6 gateway as ::0  and updates the comment

This brings it in line with 1.2.2-r20