### PR TITLE
pbr-1.2.3-90-pbr: restore check_dnsmasq_nftset lost from init.d/pbr

### DIFF
--- a/files/etc/uci-defaults/90-pbr
+++ b/files/etc/uci-defaults/90-pbr
@@ -46,6 +46,11 @@ uci -q delete pbr.config.webui_show_ignore_target
 
 # ── Part 2: NFT resolver setup ───────────────────────────────────────
 
+check_dnsmasq_nftset() {
+	[ -z "$dnsmasq_features" ] && dnsmasq_features="$(dnsmasq --version | grep -m1 'Compile time options:' | cut -d: -f2) "
+	[ "${dnsmasq_features#* nftset }" != "$dnsmasq_features" ]
+}
+
 if [ "$(uci_get 'pbr' 'config' 'resolver_set')" != 'dnsmasq.nftset' ]; then
 	if check_dnsmasq_nftset; then
 		echo -n "Setting resolver_set to 'dnsmasq.nftset'... "


### PR DESCRIPTION
/etc/init.d/pbr no longer defines check_dnsmasq_nftset(), so 90-pbr's Part 2 nft resolver setup failed when checking dnsmasq's compile-time nftset support.

Re-add the function locally in 90-pbr, copied from the older init.d/pbr implementation.

This should solve : https://github.com/mossdef-org/pbr/issues/135