### PR TITLE
pbr-1.2.3: port xfrm/point-to-point support

### DIFF
--- a/files/lib/pbr/network.uc
+++ b/files/lib/pbr/network.uc
@@ -110,10 +110,31 @@ function create_network(fs_mod, config, sh, pkg, platform, V) {
 		return i;
 	}
 	function is_xray(iface) { return get_xray_traffic_port(iface) != null; }
+	function is_xfrm_interface(iface) { let _p = network_get_protocol(iface); return _p != null && substr(_p, 0, 4) == 'xfrm'; }
 	function is_tunnel(iface) {
 		return is_dslite(iface) || is_l2tp(iface) || is_oc(iface) || is_ovpn(iface) ||
 			is_pptp(iface) || is_softether(iface) || is_netbird(iface) ||
-			is_tailscale(iface) || is_tor(iface) || is_wg(iface);
+			is_tailscale(iface) || is_tor(iface) || is_wg(iface) || is_xfrm_interface(iface);
+	}
+
+	// ── Device-level Link Detectors ─────────────────────────────────
+	// dev-based (not iface-based): used for point-to-point gateway/route
+	// fallbacks, mirroring the shell version's is_point_to_point/is_xfrm/is_p2p.
+	// Uses `-o link show` (not `address show`) since POINTOPOINT is a link
+	// flag, not something reliably reported by `ip address show` for all
+	// interface types.
+	function is_point_to_point(dev) {
+		if (!dev) return false;
+		let out = sh.exec(pkg.ip_full + ' -o link show dev ' + sh.quote(dev) + ' 2>/dev/null');
+		return index(out, 'POINTOPOINT') >= 0;
+	}
+	function is_xfrm(dev) {
+		if (!dev) return false;
+		let out = sh.exec(pkg.ip_full + ' -o -d link show dev ' + sh.quote(dev) + ' 2>/dev/null');
+		return !!match(out, /\bxfrm\b/);
+	}
+	function is_p2p(dev) {
+		return is_point_to_point(dev) || is_xfrm(dev);
 	}
 
 	// ── Interface Classification ────────────────────────────────────
@@ -226,7 +247,7 @@ function create_network(fs_mod, config, sh, pkg, platform, V) {
 				gw = any_via_from_route(out2);
 			}
 			// Raise warning if no gw and not point-to-point
-			if (!gw && warnings && index(sh.exec(pkg.ip_full + ' address show dev ' + sh.quote(dev) + ' 2>/dev/null'), 'POINTOPOINT') < 0)
+			if (!gw && warnings && !is_p2p(dev))
 				push(warnings, { code: 'warningInterfaceRoutingUnknownGateway4', info: 'interface:' + iface + '; device:' + dev + ' ' });
 		}
 		return gw;
@@ -253,7 +274,7 @@ function create_network(fs_mod, config, sh, pkg, platform, V) {
 				}
 			}
 			// Raise warning if no gw and not point-to-point
-			if (!gw && warnings && index(sh.exec(pkg.ip_full + ' address show dev ' + sh.quote(dev) + ' 2>/dev/null'), 'POINTOPOINT') < 0)
+			if (!gw && warnings && !is_p2p(dev))
 				push(warnings, { code: 'warningInterfaceRoutingUnknownGateway6', info: 'interface:' + iface + '; device:' + dev + ' ' });
 		}
 		return gw;
@@ -377,8 +398,9 @@ function create_network(fs_mod, config, sh, pkg, platform, V) {
 		uci_get_device,
 		is_dslite, is_l2tp, is_oc, is_ovpn, is_pptp,
 		is_softether, is_netbird, is_tailscale,
-		is_wg, is_wg_server, is_tor, is_xray, is_tunnel,
+		is_wg, is_wg_server, is_tor, is_xray, is_xfrm_interface, is_tunnel,
 		get_xray_traffic_port,
+		is_point_to_point, is_xfrm, is_p2p,
 		is_wan, is_uplink, is_uplink4, is_uplink6, is_split_uplink,
 		is_default_dev, is_disabled_interface, is_lan,
 		is_ignored_interface, is_tor_running,

--- a/files/lib/pbr/pbr.uc
+++ b/files/lib/pbr/pbr.uc
@@ -748,13 +748,13 @@ function create_pbr(fs_mod, uci_mod, ubus_mod) {
 			if (gw4 || cfg.strict_enforcement) {
 				if (gw4)
 					ipv4_error = sh.try_cmd(state.errors, pkg.ip_full, '-4', 'route', 'replace', 'default', 'via', gw4, 'dev', dev4, 'table', tid) ? 0 : 1;
-				else if (index(sh.exec(pkg.ip_full + ' address show dev ' + sh.quote(dev4)), 'POINTOPOINT') >= 0)
+				else if (net.is_p2p(dev4))
 					ipv4_error = sh.try_cmd(state.errors, pkg.ip_full, '-4', 'route', 'replace', 'default', 'dev', dev4, 'table', tid) ? 0 : 1;
 				else
 					ipv4_error = sh.try_cmd(state.errors, pkg.ip_full, '-4', 'route', 'replace', 'unreachable', 'default', 'table', tid) ? 0 : 1;
 				if (sh.try_ip(state.errors, '-4', 'rule', 'replace', 'fwmark', mark + '/' + cfg.fw_mask, 'table', tid, 'priority', priority) != true)
 					ipv4_error = 1;
-			} else if (index(sh.exec(pkg.ip_full + ' address show dev ' + sh.quote(dev4)), 'POINTOPOINT') >= 0) {
+			} else if (net.is_p2p(dev4)) {
 				ipv4_error = sh.try_cmd(state.errors, pkg.ip_full, '-4', 'route', 'replace', 'default', 'dev', dev4, 'table', tid) ? 0 : 1;
 				if (sh.try_ip(state.errors, '-4', 'rule', 'replace', 'fwmark', mark + '/' + cfg.fw_mask, 'table', tid, 'priority', priority) != true)
 					ipv4_error = 1;
@@ -775,13 +775,13 @@ function create_pbr(fs_mod, uci_mod, ubus_mod) {
 			if (gw6 || cfg.strict_enforcement) {
 				if (gw6)
 					ipv6_error = sh.try_cmd(state.errors, pkg.ip_full, '-6', 'route', 'replace', 'default', 'via', gw6, 'dev', dev6, 'table', tid, 'metric', cfg.uplink_interface6_metric) ? 0 : 1;
-				else if (index(sh.exec(pkg.ip_full + ' address show dev ' + sh.quote(dev6)), 'POINTOPOINT') >= 0)
+				else if (net.is_p2p(dev6))
 					ipv6_error = sh.try_cmd(state.errors, pkg.ip_full, '-6', 'route', 'replace', 'default', 'dev', dev6, 'table', tid, 'metric', cfg.uplink_interface6_metric) ? 0 : 1;
 				else
 					ipv6_error = sh.try_cmd(state.errors, pkg.ip_full, '-6', 'route', 'replace', 'unreachable', 'default', 'table', tid) ? 0 : 1;
 				if (sh.try_ip(state.errors, '-6', 'rule', 'replace', 'fwmark', mark + '/' + cfg.fw_mask, 'table', tid, 'priority', priority) != true)
 					ipv6_error = 1;
-			} else if (index(sh.exec(pkg.ip_full + ' address show dev ' + sh.quote(dev6)), 'POINTOPOINT') >= 0) {
+			} else if (net.is_p2p(dev6)) {
 				ipv6_error = sh.try_cmd(state.errors, pkg.ip_full, '-6', 'route', 'replace', 'default', 'dev', dev6, 'table', tid, 'metric', cfg.uplink_interface6_metric) ? 0 : 1;
 				if (sh.try_ip(state.errors, '-6', 'rule', 'replace', 'fwmark', mark + '/' + cfg.fw_mask, 'table', tid, 'priority', priority) != true)
 					ipv6_error = 1;
@@ -855,13 +855,13 @@ function create_pbr(fs_mod, uci_mod, ubus_mod) {
 			if (gw4 || cfg.strict_enforcement) {
 				if (gw4)
 					ipv4_error = sh.try_cmd(state.errors, pkg.ip_full, '-4', 'route', 'replace', 'default', 'via', gw4, 'dev', dev4, 'table', tid) ? 0 : 1;
-				else if (index(sh.exec(pkg.ip_full + ' address show dev ' + sh.quote(dev4)), 'POINTOPOINT') >= 0)
+				else if (net.is_p2p(dev4))
 					ipv4_error = sh.try_cmd(state.errors, pkg.ip_full, '-4', 'route', 'replace', 'default', 'dev', dev4, 'table', tid) ? 0 : 1;
 				else
 					ipv4_error = sh.try_cmd(state.errors, pkg.ip_full, '-4', 'route', 'replace', 'unreachable', 'default', 'table', tid) ? 0 : 1;
 				if (sh.try_ip(state.errors, '-4', 'rule', 'replace', 'fwmark', mark + '/' + cfg.fw_mask, 'table', tid, 'priority', priority) != true)
 					ipv4_error = 1;
-			} else if (index(sh.exec(pkg.ip_full + ' address show dev ' + sh.quote(dev4)), 'POINTOPOINT') >= 0) {
+			} else if (net.is_p2p(dev4)) {
 				ipv4_error = sh.try_cmd(state.errors, pkg.ip_full, '-4', 'route', 'replace', 'default', 'dev', dev4, 'table', tid) ? 0 : 1;
 				if (sh.try_ip(state.errors, '-4', 'rule', 'replace', 'fwmark', mark + '/' + cfg.fw_mask, 'table', tid, 'priority', priority) != true)
 					ipv4_error = 1;
@@ -881,13 +881,13 @@ function create_pbr(fs_mod, uci_mod, ubus_mod) {
 			if (gw6 || cfg.strict_enforcement) {
 				if (gw6)
 					ipv6_error = sh.try_cmd(state.errors, pkg.ip_full, '-6', 'route', 'replace', 'default', 'via', gw6, 'dev', dev6, 'table', tid, 'metric', cfg.uplink_interface6_metric) ? 0 : 1;
-				else if (index(sh.exec(pkg.ip_full + ' address show dev ' + sh.quote(dev6)), 'POINTOPOINT') >= 0)
+				else if (net.is_p2p(dev6))
 					ipv6_error = sh.try_cmd(state.errors, pkg.ip_full, '-6', 'route', 'replace', 'default', 'dev', dev6, 'table', tid, 'metric', cfg.uplink_interface6_metric) ? 0 : 1;
 				else
 					ipv6_error = sh.try_cmd(state.errors, pkg.ip_full, '-6', 'route', 'replace', 'unreachable', 'default', 'table', tid) ? 0 : 1;
 				if (sh.try_ip(state.errors, '-6', 'rule', 'replace', 'fwmark', mark + '/' + cfg.fw_mask, 'table', tid, 'priority', priority) != true)
 					ipv6_error = 1;
-			} else if (index(sh.exec(pkg.ip_full + ' address show dev ' + sh.quote(dev6)), 'POINTOPOINT') >= 0) {
+			} else if (net.is_p2p(dev6)) {
 				ipv6_error = sh.try_cmd(state.errors, pkg.ip_full, '-6', 'route', 'replace', 'default', 'dev', dev6, 'table', tid, 'metric', cfg.uplink_interface6_metric) ? 0 : 1;
 				if (sh.try_ip(state.errors, '-6', 'rule', 'replace', 'fwmark', mark + '/' + cfg.fw_mask, 'table', tid, 'priority', priority) != true)
 					ipv6_error = 1;


### PR DESCRIPTION
Add is_xfrm(), is_point_to_point(), is_p2p() device-level detectors and an is_xfrm_interface() protocol-level detector to network.uc, porting the shell version's v1.2.2 is_p2p patch.

- is_xfrm_interface(iface): true when the interface's proto starts with "xfrm"; wired into is_tunnel() alongside the existing tunnel protocol checks.
- is_point_to_point(dev)/is_xfrm(dev): parse `ip -o link show` / `ip -o -d link show` output for a given device. Kept as a literal match of the bash reference: is_point_to_point() uses a plain substring check (bash uses `grep -q`, no -w), is_xfrm() uses a word-boundary regex (bash uses `grep -qw`) to avoid false-matching "xfrm" inside an unrelated device name.
- is_p2p(dev) = is_point_to_point(dev) || is_xfrm(dev).

Fix get_gateway4()/get_gateway6() to use is_p2p(dev) instead of grepping `ip address show` output for POINTOPOINT, which doesn't reliably report the flag for all interface types and never detected xfrm devices at all.

Replace all 8 point-to-point fallback checks in pbr.uc's interface_routing() create/reload paths (ipv4+ipv6) with net.is_p2p(dev4)/net.is_p2p(dev6), removing the same `ip address show`-based POINTOPOINT grep.

Verified against a locally built ucode interpreter: both files compile clean as modules, and is_point_to_point/is_xfrm/is_p2p were runtime-tested against real `ip link show` output for tun, tap, and xfrm devices, plus get_gateway4()'s warning-suppression path.