### PR TITLE
pbr-1.2.3: dns_policy_routing fix nft syntax error on default DNS port

### DIFF
--- a/files/lib/pbr/pbr.uc
+++ b/files/lib/pbr/pbr.uc
@@ -314,8 +314,8 @@ function create_pbr(fs_mod, uci_mod, ubus_mod) {
 			let param4 = '', param6 = '';
 			let inline_set_ipv4_empty = false, inline_set_ipv6_empty = false;
 	
-			let dest4 = 'dport 53 dnat ip to ' + dest_dns_ipv4 + ':' + dest_dns_port;
-			let dest6 = 'dport 53 dnat ip6 to ' + dest_dns_ipv6 + ':' + dest_dns_port;
+			let dest4 = 'dport 53 dnat ip to ' + dest_dns_ipv4 + (dest_dns_port ? ':' + dest_dns_port : '');
+			let dest6 = 'dport 53 dnat ip6 to ' + dest_dns_ipv6 + (dest_dns_port ? ':' + dest_dns_port : '');
 	
 			if (src_addr) {
 				let r = nft.classify_addr(src_addr, 'src', null, null, null, false);


### PR DESCRIPTION
When dest_dns_port was unset (i.e. the default port 53 was used), the generated dnat target always appended ':' + dest_dns_port:

    dnat ip to 1.1.1.1:

The trailing colon with no port after it is invalid nft syntax and broke rule loading:

    /var/run/pbr.nft:43:100-106: Error: syntax error, unexpected comment

Only append ':<port>' when dest_dns_port is actually set; omitting it entirely (dnat ip to <addr>) is valid nft and preserves the original destination port, which is correct for the default-port case.