### PR TITLE
pbr-1.2.3: filter_options: fix negation state leaking across tokens

### DIFF
--- a/files/lib/pbr/validators.uc
+++ b/files/lib/pbr/validators.uc
@@ -57,16 +57,17 @@ function is_family_mismatch(a, b) {
 
 function filter_options(opt, values) {
 	if (!values) return '';
+	let is_negative = str_contains(opt, '_negative');
+	let base_opt = is_negative ? replace(opt, '_negative', '') : opt;
 	let parts = split(trim('' + values), /\s+/);
 	let ret = [];
 	for (let v in parts) {
-		if (str_contains(opt, '_negative')) {
-			if (substr('' + v, 0, 1) != '!') continue;
-			opt = replace(opt, '_negative', '');
-		}
-		let check_val = replace(v, '!', '');
+		let negated = (substr('' + v, 0, 1) == '!');
+		if (is_negative && !negated) continue;
+		if (!is_negative && negated) continue;
+		let check_val = negated ? substr('' + v, 1) : '' + v;
 		let ok = false;
-		switch (opt) {
+		switch (base_opt) {
 		case 'phys_dev': ok = is_phys_dev(check_val); break;
 		case 'mac_address': ok = is_mac_address(check_val); break;
 		case 'domain': ok = is_domain(check_val); break;


### PR DESCRIPTION
filter_options() mutated its own `opt` parameter in place the first time it encountered a negated ('!'-prefixed) token:

    if (str_contains(opt, '_negative')) {
        if (substr('' + v, 0, 1) != '!') continue;
        opt = replace(opt, '_negative', '');
    }

Since `opt` is reassigned inside the loop, this permanently strips '_negative' off for every remaining iteration, silently disabling the "must start with !" requirement for the rest of that call's token list. On top of that, the non-negative branch never checked for the *absence* of '!' either, so a plain call like filter_options('ipv4', ...) matched negated tokens too.

Net effect: a single token could be classified into both the positive and negative group for its address family whenever a policy's src_addr/dest_addr mixed a negated entry with anything else of the same family (or even a single negated entry on its own, since the positive branch matched it unconditionally). Callers that loop over both groups (dns_policy_process, policy_process) would then route the same address(es) more than once, producing duplicate/overlapping nft rules - amplified further in policy_process's nested src x dest loop (up to 4x for a single negated src + single negated dest).

Fix: compute is_negative/base_opt once, before the loop, and require each token's negation state to match the group being filtered rather than mutating shared state as we go. Each token now lands in exactly one of the ten filter groups.

Verified via simulation that every token previously matched under any group is still matched exactly once post-fix, so the "unknown entry" validation in policy_process is unaffected.