### PR TITLE
pbr-1.2.3: stop pbr from taking down fw4's own forwarding on failure

### DIFF
--- a/files/lib/pbr/nft.uc
+++ b/files/lib/pbr/nft.uc
@@ -293,6 +293,7 @@ function create_nft(fs_mod, config, sh, output, pkg, platform, network, V, state
 			} else {
 				push(state.errors, { code: 'errorNftMainFileInstall', info: pkg.nft_temp_file });
 				output.failn();
+				sh.run('fw4 -q reload');
 				return false;
 			}
 		}
@@ -671,7 +672,7 @@ function create_nft(fs_mod, config, sh, output, pkg, platform, network, V, state
 				let chains = split(pkg.chains_list, ' ');
 				for (let c in [...chains, 'dstnat']) {
 					c = lc(c);
-					nft_call('flush', 'chain', 'inet', pkg.nft_table, c);
+					nft_call('flush', 'chain', 'inet', pkg.nft_table, pkg.nft_prefix + '_' + c);
 				}
 				break;
 			}


### PR DESCRIPTION
nft.cleanup()'s 'main_chains' case runs at the start of every pbr run (success or fail) and is meant to clear pbr's own chain content before rebuilding it:

    let chains = split(pkg.chains_list, ' ');
    for (let c in [...chains, 'dstnat']) {
        c = lc(c);
        nft_call('flush', 'chain', 'inet', pkg.nft_table, c);
    }

pkg.chains_list holds bare suffixes ("prerouting output forward"), and every other place in the codebase that uses those values prepends pkg.nft_prefix before building a chain name (see nft_file.init(), nft_file.show()). This was the one place that didn't - so instead of flushing pbr's own pbr_prerouting/pbr_output/pbr_forward/pbr_dstnat, it flushed fw4's real, shared base chains of the same bare names, including fw4's own "dstnat" (NAT port forwards) and "forward" (LAN <-> WAN/VPN forwarding, default policy drop).

Confirmed via nft -c list ruleset diff: with the bug, forward/output/ prerouting/dstnat lose every fw4-owned rule (zone jumps, conntrack helper assignment, port forwards) the moment cleanup() runs. Because forward's policy is drop, this is a full LAN forwarding outage, not just a pbr-specific gap. It's normally invisible because a successful run's later 'fw4 -q reload' fully rebuilds fw4's ruleset a few seconds later - but if nft_file.apply() fails validation (e.g. a bad rule from a misconfigured policy) and that reload is skipped, the outage is left in place indefinitely.

Fix: prefix with pkg.nft_prefix so cleanup only ever touches pbr's own chains. Verified via before/after nft -c list ruleset diff that fw4's base chains now stay fully intact across a failed pbr run - the only remaining differences are rule counters resetting, which is expected on any reload.

Also re-enable the fw4 reload on nft_file.apply()'s failure path, which had been disabled entirely:

    push(state.errors, { code: 'errorNftMainFileInstall', ... });
    output.failn();
    sh.run('fw4 -q reload');
    return false;

pkg.nft_main_file is unconditionally unlinked by nft_file.init() at the start of every run, so there's no stale/broken content this can pick up - worst case it reloads fw4 with no pbr rules included. Kept as a second layer of defense alongside the main_chains fix above, for any other way apply() could fail or pbr could be interrupted between cleanup() and apply().

Summary
Fixes a firewall outage that could occur whenever pbr failed to install its nft ruleset (e.g. due to a misconfigured policy). Root cause: nft.cleanup()'s main_chains step was flushing fw4's own shared base chains (forward, output, prerouting, dstnat) instead of pbr's own pbr_-prefixed chains, due to a missing pkg.nft_prefix prefix. Since forward's default policy is drop, this briefly took down all LAN forwarding on every pbr run, and left it down indefinitely if nft_file.apply() then failed validation and skipped the fw4 -q reload that would otherwise have repaired it.

Changes
main_chains cleanup now flushes pbr_<chain> instead of <chain>. nft_file.apply() now reloads fw4 on its failure path too, as a second layer of defense (safe: pkg.nft_main_file is already unlinked unconditionally at the start of every run, so there's nothing stale to reload).

Testing
Captured nft -c list ruleset before/after a fw4 reload while pbr was failing to start, with only the main_chains fix applied: no structural differences remained (only expected counter resets) — confirms fw4's own chains stay intact through a failed pbr run. Compare against the pre-fix capture, which showed forward/output/prerouting/dstnat completely empty of their zone-jump rules during the same failure.