### PR TITLE
pbr-1.2.2: nft_file/cleanup: stop taking down fw4's own forwarding on…

### DIFF
--- a/files/etc/init.d/pbr
+++ b/files/etc/init.d/pbr
@@ -1067,6 +1067,7 @@ nft_file() {
 			else
 				json add error 'errorNftMainFileInstall' "$nftTempFile"
 				output_failn
+				fw4 -q reload >/dev/null 2>&1
 			fi
 		;;
 		install:netifd)
@@ -1299,7 +1300,7 @@ cleanup() {
 			main_chains)
 				for i in $chainsList dstnat; do
 					i="$(str_to_lower "$i")"
-					nft_call flush chain inet "$nftTable" "${i}"
+					nft_call flush chain inet "$nftTable" "${nftPrefix}_${i}"
 				done
 			;;
 			marking_chains)


### PR DESCRIPTION
… failure

Backport of the same fix already applied to the ucode port.

cleanup()'s 'main_chains' case is meant to clear pbr's own chain content before rebuilding it:

    main_chains)
        for i in $chainsList dstnat; do
            i="$(str_to_lower "$i")"
            nft_call flush chain inet "$nftTable" "${i}"
        done
    ;;

$chainsList holds bare suffixes ("prerouting output forward"), and every place that builds a real chain name from it prefixes with ${nftPrefix}_ first - see nft_file() create:main a few dozen lines earlier, which consistently uses "${nftPrefix}_${chain}". This was the one place that didn't, so instead of flushing pbr's own pbr_prerouting/pbr_output/pbr_forward/pbr_dstnat, it flushed fw4's real, shared base chains of the same bare names - including fw4's own "dstnat" (NAT port forwards) and "forward" (LAN <-> WAN/VPN forwarding, default policy drop).

This predates the ucode port - it's the same bug in the original shell implementation, faithfully carried over rather than introduced during the rewrite.

Confirmed via nft -c list ruleset diff (on the ucode side, same logic): with the bug, forward/output/prerouting/dstnat lose every fw4-owned rule (zone jumps, conntrack helper assignment, port forwards) the moment cleanup() runs. Since forward's policy is drop, this is a full LAN forwarding outage, not just a pbr-specific gap. Normally invisible because a successful run's later `fw4 -q reload` (in install:main) fully rebuilds fw4's ruleset a few seconds later - but if that install fails validation and the reload is skipped, the outage is left in place indefinitely.

Fix: prefix with ${nftPrefix}_ so cleanup only ever touches pbr's own chains.

Also add the same reload-on-failure safety net used in the ucode fix: install:main's failure branch never called `fw4 -q reload` at all, only the success branch did:

    if nft_call -c -f "$nftTempFile" && \
        cp -f "$nftTempFile" "$nftMainFile"; then
        output_okn
        fw4 -q reload >/dev/null 2>&1
    else
        json add error 'errorNftMainFileInstall' "$nftTempFile"
        output_failn
    fi

create:main already unconditionally removes nftTempFile/nftMainFile at the start of every run, so there's no stale/broken content this reload could pick up on the failure path - worst case it reloads fw4 with no pbr rules included. Kept as a second layer of defense for any other way install:main could fail or pbr could be interrupted mid-run, alongside the main_chains fix above.