### PR TITLE
pbr-1.2.3: offer tor as a selectable interface in the WebUI

### DIFF
--- a/files/lib/pbr/network.uc
+++ b/files/lib/pbr/network.uc
@@ -349,6 +349,15 @@ function create_network(fs_mod, config, sh, pkg, platform, V) {
 				push(webui_parts, value);
 				webui_labels[value] = 'mwan4:strategy:' + strategy;
 			}
+			// Add the Tor pseudo interface. Tor has no corresponding
+			// network.interface section (it redirects via nft dstnat rules,
+			// not device routing), so it can never be discovered by the
+			// foreach() loop above; expose it whenever the package is
+			// installed, mirroring how 'ignore' is always offered.
+			if (!is_ignored_interface('tor') && stat(pkg.tor_config_file)) {
+				push(webui_parts, 'tor');
+				webui_labels['tor'] = 'tor';
+			}
 			push(webui_parts, 'ignore');
 			webui_labels['ignore'] = 'ignore';
 			env.ifaces_supported = join(' ', parts);


### PR DESCRIPTION
The Tor pseudo interface could not be chosen in the LuCI 'Interface' dropdown of a policy, so Tor routing was unreachable through the UI even though the whole backend path for it was present and working.

The list the WebUI renders (env.webui_interfaces, served over luci.pbr getInterfaces) is built in network.uc load() by walking the 'interface' sections of /etc/config/network. Tor has no such section and never will: it is not a routed device but a redirect target, implemented as nft dstnat rules pointing at Tor's local TransPort / DNSPort. So the foreach() loop can never discover it, and it silently fell out of the dropdown.

The list already carries entries that do not come from that loop -- 'ignore' is appended unconditionally and each mwan4 strategy is pushed as a synthetic 'mwan4_strategy_<name>' entry. Tor was simply the one pseudo interface that never got the same treatment.

Nothing else needed changing; the rest of the path already accepts 'tor' as a policy interface:

 - is_supported_interface('tor') returns true through is_tunnel() -> is_tor(), so policy_process() does not reject it with errorPolicyUnknownInterface.
 - init.d/pbr already declares the literal "tor" as a valid value for the interface, icmp_interface, ignored_interface and supported_interface options.
 - policy_routing() has a dedicated tor branch emitting the five dstnat redirect rules, and interface_process.tor('create') runs before policies are processed, so the ports and the registry entry exist by the time they are needed.

 - network.uc: push 'tor' (and its label) into the WebUI interface list, next to where 'ignore' and the mwan4 strategies are added. Gated on /etc/tor/torrc existing, so the entry only appears when the tor package is actually installed, and on tor not being listed in ignored_interface, so an explicit ignore still hides it. Only webui_interfaces is touched; ifaces_supported keeps listing real network interfaces.

Verified against the mock test suite: a policy with interface 'tor' is accepted without errors, registers in the gateway list as '53->9053 / 80,443->9040', and emits the expected five redirect rules into pbr_dstnat.

Follow-ups, not included here:
 - _get_tor_dns_port()/_get_tor_traffic_port() match /Port\s+\S+:(\d+)/, which only recognises the documented 'address:port' torrc form. A bare 'DNSPort 9153' does not match and silently falls back to 9053/9040, redirecting Tor DNS and traffic to a closed port with no error raised. Bare-port lines with the default numbers still work by coincidence, which is why this has gone unnoticed.
 - A tor policy with src_port set emits invalid nft: the tor branch clears dest_port and proto, but leaves src_port, and the empty proto is then promoted to 'tcp udp', producing rules that match 'tcp sport ... udp dport ...'. dest_port should probably not be the only port cleared for tor.
 - In the tor branch the ipv4_error/ipv6_error flags are tested inside the tor_rules loop and never reset, so a single failed insertion is reported up to five times. The non-tor branch tests them after the loop.
 - interface_process.tor('destroy') is a no-op; the switch only handles create/reload/reload_interface. Harmless, the nft flush does the real cleanup, but the call reads as if it did something.
 - tests/run_tests.sh applies sed '/get_rt_tables_id/,/^};/ s/m\[1\]/m[2]/' to the patched pbr.uc. No line after that match starts with '};' at column 0, so the range runs to EOF and rewrites every m[1] in the tail of the file -- including both tor port helpers. Any test covering the tor ports will read as broken (':null') even when the code is correct.