### PR TITLE
pbr-1.2.3: guard IP rule priority exhaustion

### DIFF
--- a/files/etc/init.d/pbr
+++ b/files/etc/init.d/pbr
@@ -31,7 +31,7 @@ else
 fi
 
 readonly packageName='pbr'
-readonly initCompat='34'
+readonly initCompat='35'
 readonly _ucode="ucode -S -L /lib/${packageName} -L /lib/mwan4 /lib/${packageName}/cli.uc --"
 
 # shellcheck disable=SC1091

--- a/files/lib/pbr/pbr.uc
+++ b/files/lib/pbr/pbr.uc
@@ -929,6 +929,10 @@ function create_pbr(fs_mod, uci_mod, ubus_mod) {
 				push(state.errors, { code: 'errorInterfaceMarkOverflow', info: iface });
 				return;
 			}
+			if (+_iface_priority <= 0) {
+				push(state.errors, { code: 'errorInterfacePriorityExhausted', info: iface });
+				return;
+			}
 	
 			let dev4 = net.network_get_device(iface);
 			if (!dev4) dev4 = net.network_get_physdev(iface);
@@ -1038,6 +1042,7 @@ function create_pbr(fs_mod, uci_mod, ubus_mod) {
 
 	interface_process.create_global_rules = function() {
 		let prio = '' + iface_priority;
+		let priority_exhausted = false;
 		config.uci_ctx('network').foreach('network', 'interface', function(s_iface) {
 			let name = s_iface['.name'];
 			if (net.is_wg_server(name) && !net.is_ignored_interface(name)) {
@@ -1045,6 +1050,13 @@ function create_pbr(fs_mod, uci_mod, ubus_mod) {
 				let listen_port = config.uci_ctx('network').get('network', name, 'listen_port');
 				if (disabled != '1' && listen_port) {
 					if (cfg.uplink_interface4) {
+						if (+prio <= 0) {
+							if (!priority_exhausted) {
+								push(state.errors, { code: 'errorInterfacePriorityExhausted', info: name });
+								priority_exhausted = true;
+							}
+							return;
+						}
 						let tbl = pkg.ip_table_prefix + '_' + cfg.uplink_interface4;
 						system(pkg.ip_full + ' -4 rule del sport ' + listen_port + ' table ' + tbl + ' priority ' + prio + ' 2>/dev/null');
 						sh.ip('-4', 'rule', 'add', 'sport', listen_port, 'table', tbl, 'priority', prio);
@@ -1057,6 +1069,17 @@ function create_pbr(fs_mod, uci_mod, ubus_mod) {
 				}
 			}
 		});
+		// prio may have been left at <= 0 by the exhaustion guard above: never
+		// issue an 'ip rule' at priority 0, it collides with the kernel's own
+		// 'from all lookup local' rule (see 12b993766718). Bail out the same
+		// way the tail of this function does: iface_priority stays a string,
+		// and the returned 0 is unused, the sole caller ignores it.
+		if (+prio <= 0) {
+			if (!priority_exhausted)
+				push(state.errors, { code: 'errorInterfacePriorityExhausted', info: pkg.name });
+			iface_priority = prio;
+			return 0;
+		}
 		system(pkg.ip_full + ' -4 rule del priority ' + prio + ' 2>/dev/null');
 		system(pkg.ip_full + ' -4 rule del lookup main suppress_prefixlength ' + cfg.prefixlength + ' 2>/dev/null');
 		sh.try_cmd(state.errors, pkg.ip_full, '-4', 'rule', 'add', 'lookup', 'main', 'suppress_prefixlength',

--- a/files/lib/pbr/pkg.uc
+++ b/files/lib/pbr/pkg.uc
@@ -9,7 +9,7 @@
 const pkg = {
 	name: 'pbr',
 	version: 'dev-test',
-	compat: '34',
+	compat: '35',
 	config_file: '/etc/config/pbr',
 	debug_file: '/var/run/pbr.debug',
 	lock_file: '/var/run/pbr.lock',
@@ -83,6 +83,7 @@ function get_text(code, cfg, ...args) {
 		errorPolicyProcessUnknownEntry:        sprintf("Unknown entry in policy '%s'", a1),
 		errorInterfaceRoutingEmptyValues:      "Received empty tid/mark or interface name when setting up routing",
 		errorInterfaceMarkOverflow:            sprintf("Interface mark for '%s' exceeds the fwmask value", a1),
+		errorInterfacePriorityExhausted:       sprintf("No IP rule priority left to allocate for '%s'", a1),
 		errorFailedToResolve:                  sprintf("Failed to resolve '%s'", a1),
 		errorInvalidOVPNConfig:                sprintf("Invalid OpenVPN config for '%s' interface", a1),
 		errorNftMainFileInstall:               sprintf("Failed to install fw4 nft file '%s'", a1),

--- a/tests/04_policies/01_start_dynamic_routing
+++ b/tests/04_policies/01_start_dynamic_routing
@@ -9,7 +9,7 @@ let result = pbr.start_service(['on_start']);
 // result should be non-null (procd data)
 let checks = [
 	['result_not_null',    result != null],
-	['has_compat',         result.packageCompat == 34],
+	['has_compat',         result.packageCompat == 35],
 	['has_gateways',       type(result.gateways) == 'array'],
 	['has_errors',         type(result.errors) == 'array'],
 	['has_warnings',       type(result.warnings) == 'array'],

--- a/tests/05_interfaces/12_priority_exhaustion_guard
+++ b/tests/05_interfaces/12_priority_exhaustion_guard
@@ -1,0 +1,198 @@
+Testing that interface_enumerate() and create_global_rules() refuse to
+allocate an IP rule priority <= 0 once uplink_ip_rules_priority is
+exhausted by the interface count, instead of issuing 'ip rule ... priority 0'
+(which collides with the kernel's own 'from all lookup local' rule).
+
+-- File uci/network.json --
+{
+	"interface": [
+		{ ".name": "loopback", "device": "lo", "proto": "static", "ipaddr": "127.0.0.1", "netmask": "255.0.0.0" },
+		{ ".name": "lan", "device": "br-lan", "proto": "static", "ipaddr": "192.168.1.1/24" },
+		{ ".name": "wan", "device": "eth1", "proto": "dhcp" },
+		{ ".name": "wan2x", "device": "eth2", "proto": "dhcp" },
+		{ ".name": "wan3x", "device": "eth3", "proto": "dhcp" },
+		{ ".name": "wan4x", "device": "eth4", "proto": "dhcp" },
+		{ ".name": "wan5x", "device": "eth5", "proto": "dhcp" },
+		{ ".name": "wan6x", "device": "eth6", "proto": "dhcp" },
+		{ ".name": "wan7x", "device": "eth7", "proto": "dhcp" },
+		{ ".name": "wan8x", "device": "eth8", "proto": "dhcp" },
+		{ ".name": "wan9x", "device": "eth9", "proto": "dhcp" },
+		{ ".name": "wan10x", "device": "eth10", "proto": "dhcp" },
+		{ ".name": "wan11x", "device": "eth11", "proto": "dhcp" },
+		{ ".name": "wan12x", "device": "eth12", "proto": "dhcp" },
+		{ ".name": "wan13x", "device": "eth13", "proto": "dhcp" },
+		{ ".name": "wan14x", "device": "eth14", "proto": "dhcp" },
+		{ ".name": "wan15x", "device": "eth15", "proto": "dhcp" },
+		{ ".name": "wan16x", "device": "eth16", "proto": "dhcp" },
+		{ ".name": "wan17x", "device": "eth17", "proto": "dhcp" },
+		{ ".name": "wan18x", "device": "eth18", "proto": "dhcp" },
+		{ ".name": "wan19x", "device": "eth19", "proto": "dhcp" },
+		{ ".name": "wan20x", "device": "eth20", "proto": "dhcp" },
+		{ ".name": "wan21x", "device": "eth21", "proto": "dhcp" },
+		{ ".name": "wan22x", "device": "eth22", "proto": "dhcp" },
+		{ ".name": "wan23x", "device": "eth23", "proto": "dhcp" },
+		{ ".name": "wan24x", "device": "eth24", "proto": "dhcp" },
+		{ ".name": "wan25x", "device": "eth25", "proto": "dhcp" },
+		{ ".name": "wan26x", "device": "eth26", "proto": "dhcp" },
+		{ ".name": "wan27x", "device": "eth27", "proto": "dhcp" },
+		{ ".name": "wan28x", "device": "eth28", "proto": "dhcp" },
+		{ ".name": "wan29x", "device": "eth29", "proto": "dhcp" },
+		{ ".name": "wan30x", "device": "eth30", "proto": "dhcp" },
+		{ ".name": "wan31x", "device": "eth31", "proto": "dhcp" },
+		{ ".name": "wan32x", "device": "eth32", "proto": "dhcp" },
+		{ ".name": "wan33x", "device": "eth33", "proto": "dhcp" },
+		{ ".name": "wan34x", "device": "eth34", "proto": "dhcp" },
+		{ ".name": "wan35x", "device": "eth35", "proto": "dhcp" },
+		{ ".name": "wan36x", "device": "eth36", "proto": "dhcp" },
+		{ ".name": "wan37x", "device": "eth37", "proto": "dhcp" },
+		{ ".name": "wan38x", "device": "eth38", "proto": "dhcp" },
+		{ ".name": "wan39x", "device": "eth39", "proto": "dhcp" },
+		{ ".name": "wan40x", "device": "eth40", "proto": "dhcp" },
+		{ ".name": "wan41x", "device": "eth41", "proto": "dhcp" },
+		{ ".name": "wan42x", "device": "eth42", "proto": "dhcp" },
+		{ ".name": "wan43x", "device": "eth43", "proto": "dhcp" },
+		{ ".name": "wan44x", "device": "eth44", "proto": "dhcp" },
+		{ ".name": "wan45x", "device": "eth45", "proto": "dhcp" },
+		{ ".name": "wan46x", "device": "eth46", "proto": "dhcp" },
+		{ ".name": "wan47x", "device": "eth47", "proto": "dhcp" },
+		{ ".name": "wan48x", "device": "eth48", "proto": "dhcp" },
+		{ ".name": "wan49x", "device": "eth49", "proto": "dhcp" },
+		{ ".name": "wan50x", "device": "eth50", "proto": "dhcp" },
+		{ ".name": "wan51x", "device": "eth51", "proto": "dhcp" },
+		{ ".name": "wan52x", "device": "eth52", "proto": "dhcp" },
+		{ ".name": "wan53x", "device": "eth53", "proto": "dhcp" },
+		{ ".name": "wan54x", "device": "eth54", "proto": "dhcp" },
+		{ ".name": "wan55x", "device": "eth55", "proto": "dhcp" },
+		{ ".name": "wan56x", "device": "eth56", "proto": "dhcp" },
+		{ ".name": "wan57x", "device": "eth57", "proto": "dhcp" },
+		{ ".name": "wan58x", "device": "eth58", "proto": "dhcp" },
+		{ ".name": "wan59x", "device": "eth59", "proto": "dhcp" },
+		{ ".name": "wan60x", "device": "eth60", "proto": "dhcp" },
+		{ ".name": "wan61x", "device": "eth61", "proto": "dhcp" },
+		{ ".name": "wan62x", "device": "eth62", "proto": "dhcp" },
+		{ ".name": "wan63x", "device": "eth63", "proto": "dhcp" },
+		{ ".name": "wan64x", "device": "eth64", "proto": "dhcp" },
+		{ ".name": "wan65x", "device": "eth65", "proto": "dhcp" },
+		{ ".name": "wan66x", "device": "eth66", "proto": "dhcp" },
+		{ ".name": "wan67x", "device": "eth67", "proto": "dhcp" },
+		{ ".name": "wan68x", "device": "eth68", "proto": "dhcp" },
+		{ ".name": "wan69x", "device": "eth69", "proto": "dhcp" },
+		{ ".name": "wan70x", "device": "eth70", "proto": "dhcp" },
+		{ ".name": "wan71x", "device": "eth71", "proto": "dhcp" },
+		{ ".name": "wan72x", "device": "eth72", "proto": "dhcp" },
+		{ ".name": "wan73x", "device": "eth73", "proto": "dhcp" },
+		{ ".name": "wan74x", "device": "eth74", "proto": "dhcp" },
+		{ ".name": "wan75x", "device": "eth75", "proto": "dhcp" },
+		{ ".name": "wan76x", "device": "eth76", "proto": "dhcp" },
+		{ ".name": "wan77x", "device": "eth77", "proto": "dhcp" },
+		{ ".name": "wan78x", "device": "eth78", "proto": "dhcp" },
+		{ ".name": "wan79x", "device": "eth79", "proto": "dhcp" },
+		{ ".name": "wan80x", "device": "eth80", "proto": "dhcp" },
+		{ ".name": "wan81x", "device": "eth81", "proto": "dhcp" },
+		{ ".name": "wan82x", "device": "eth82", "proto": "dhcp" },
+		{ ".name": "wan83x", "device": "eth83", "proto": "dhcp" },
+		{ ".name": "wan84x", "device": "eth84", "proto": "dhcp" },
+		{ ".name": "wan85x", "device": "eth85", "proto": "dhcp" },
+		{ ".name": "wan86x", "device": "eth86", "proto": "dhcp" },
+		{ ".name": "wan87x", "device": "eth87", "proto": "dhcp" },
+		{ ".name": "wan88x", "device": "eth88", "proto": "dhcp" },
+		{ ".name": "wan89x", "device": "eth89", "proto": "dhcp" },
+		{ ".name": "wan90x", "device": "eth90", "proto": "dhcp" },
+		{ ".name": "wan91x", "device": "eth91", "proto": "dhcp" },
+		{ ".name": "wan92x", "device": "eth92", "proto": "dhcp" },
+		{ ".name": "wan93x", "device": "eth93", "proto": "dhcp" },
+		{ ".name": "wan94x", "device": "eth94", "proto": "dhcp" },
+		{ ".name": "wan95x", "device": "eth95", "proto": "dhcp" },
+		{ ".name": "wan96x", "device": "eth96", "proto": "dhcp" },
+		{ ".name": "wan97x", "device": "eth97", "proto": "dhcp" },
+		{ ".name": "wan98x", "device": "eth98", "proto": "dhcp" },
+		{ ".name": "wan99x", "device": "eth99", "proto": "dhcp" },
+		{ ".name": "wan100x", "device": "eth100", "proto": "dhcp" },
+		{ ".name": "wan101x", "device": "eth101", "proto": "dhcp" },
+		{ ".name": "wan102x", "device": "eth102", "proto": "dhcp" },
+		{ ".name": "wan103x", "device": "eth103", "proto": "dhcp" },
+		{ ".name": "wan104x", "device": "eth104", "proto": "dhcp" },
+		{ ".name": "wan105x", "device": "eth105", "proto": "dhcp" },
+		{ ".name": "wan106x", "device": "eth106", "proto": "dhcp" },
+		{ ".name": "wan107x", "device": "eth107", "proto": "dhcp" },
+		{ ".name": "wan108x", "device": "eth108", "proto": "dhcp" },
+		{ ".name": "wan109x", "device": "eth109", "proto": "dhcp" },
+		{ ".name": "wan110x", "device": "eth110", "proto": "dhcp" }
+	]
+}
+-- End --
+
+-- File uci/pbr.json --
+{
+	"pbr": [
+		{
+			".name": "config",
+			"enabled": "1",
+			"fw_mask": "00ff0000",
+			"ipv6_enabled": "0",
+			"strict_enforcement": "1",
+			"uplink_interface": "wan",
+			"uplink_ip_rules_priority": "99",
+			"uplink_mark": "00010000",
+			"verbosity": "2",
+			"lan_device": ["br-lan"],
+			"resolver_instance": ["*"],
+			"debug_performance": "0"
+		}
+	],
+	"policy": [],
+	"dns_policy": [],
+	"include": []
+}
+-- End --
+
+-- Testcase --
+import create_pbr from 'pbr';
+import _pkg_mod from 'pkg';
+let get_text = _pkg_mod.get_text;
+let pbr = create_pbr();
+
+let result = pbr.start_service(['on_start']);
+let errors = result?.errors || [];
+let gateways = result?.gateways || [];
+
+let exhaustion_errors = filter(errors, e => e.code == 'errorInterfacePriorityExhausted');
+
+let min_priority = null, max_priority = null, non_positive = 0;
+for (let gw in gateways) {
+	let p = +gw.priority;
+	if (p <= 0) non_positive++;
+	if (min_priority == null || p < min_priority) min_priority = p;
+	if (max_priority == null || p > max_priority) max_priority = p;
+}
+
+let msg = get_text('errorInterfacePriorityExhausted', {}, 'wan100x');
+
+let checks = [
+	// 110 supported interfaces against uplink_ip_rules_priority=99: the first
+	// 99 take priorities 99..1, so interfaces 100..110 are skipped (11 errors),
+	// and create_global_rules() then hits its own guard on the leftover
+	// iface_priority of 0 for the suppress_prefixlength rule (1 more) = 12.
+	['exhaustion_error_count',   length(exhaustion_errors) == 12],
+	['registered_interfaces',    length(gateways) == 99],
+	['no_non_positive_priority', non_positive == 0],
+	['min_priority_is_one',      min_priority == 1],
+	['max_priority_is_99',       max_priority == 99],
+	['message_includes_iface',   index(msg, 'wan100x') >= 0],
+];
+
+let pass = 0, fail = 0;
+for (let c in checks) {
+	if (c[1]) {
+		pass++;
+	} else {
+		fail++;
+		printf("FAIL: %s\n", c[0]);
+	}
+}
+printf("priority_exhaustion_guard: %d/%d passed\n", pass, pass + fail);
+-- End --
+
+-- Expect stdout --
+priority_exhaustion_guard: 6/6 passed
+-- End --


### PR DESCRIPTION
## Problem

`interface_enumerate()` allocates an IP rule priority per supported interface by counting **down** from `cfg.uplink_ip_rules_priority`, with no floor check. The parallel firewall mark allocation, which counts **up**, is already guarded by `errorInterfaceMarkOverflow` — the priority descent had no equivalent.

Once the priorities run out, pbr issues `ip rule add ... priority 0`, which collides with the kernel's own `from all lookup local` rule, and then continues into negative priorities. Same class of bug as 12b993766718.

## Fix

- **`pbr.uc` / `interface_enumerate()`** — skip the interface with `errorInterfacePriorityExhausted` once the counter would reach 0, mirroring the mark overflow guard directly above it. Skipped interfaces are never registered in `iface_registry`, and `interface_process.create()` already bails with `if (!existing) return 0;`, so they no-op downstream exactly like mark-overflow skips do today.
- **`pbr.uc` / `create_global_rules()`** — guard the matching descent there too. This is not just symmetry: `iface_priority` is shared leftover state and the `suppress_prefixlength` rule is issued unconditionally, so guarding only `interface_enumerate()` relocates the same bug one level up. The error is pushed at most once per call rather than once per WireGuard server.
- **`pkg.uc`** — add `errorInterfacePriorityExhausted`; bump `compat` to 35.
- **`init.d/pbr`** — update `initCompat` to 35.

## Severity

Low — hardening, not a live failure. `config.uc` clamps `uplink_ip_rules_priority` to 99..32765, so this only triggers with more than ~98 enabled and supported interfaces.

## Testing

New `tests/05_interfaces/12_priority_exhaustion_guard` drives 110 supported interfaces against `uplink_ip_rules_priority=99` and asserts 99 registered interfaces spanning priorities 99→1, zero non-positive priorities, and the expected exhaustion error count. Verified bug-sensitive: with the fix stashed it fails on `exhaustion_error_count`, `registered_interfaces` and `no_non_positive_priority`.

Full suite: 46/46 passing.

## Pairs with

The luci-app-pbr change setting `LuciCompat`/`rpcdCompat` to 35. Both must land together, or the version-mismatch warning fires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)