### PR TITLE
pbr-1.2.3: restore the Tor policy warnings, split per option

### DIFF
--- a/files/etc/init.d/pbr
+++ b/files/etc/init.d/pbr
@@ -31,7 +31,7 @@ else
 fi
 
 readonly packageName='pbr'
-readonly initCompat='35'
+readonly initCompat='36'
 readonly _ucode="ucode -S -L /lib/${packageName} -L /lib/mwan4 /lib/${packageName}/cli.uc --"
 
 # shellcheck disable=SC1091

--- a/files/lib/pbr/pbr.uc
+++ b/files/lib/pbr/pbr.uc
@@ -630,6 +630,41 @@ function create_pbr(fs_mod, uci_mod, ubus_mod) {
 			push(state.errors, { code: 'errorPolicyNoInterface', info: name });
 			output.fail(); return 1;
 		}
+		if (net.is_tor(interface_name)) {
+			// Tor is a dstnat redirect, not a routed interface: the rules below
+			// hardcode ports 53/80/443 and force the dstnat chain, so these
+			// options are silently discarded (src_port additionally produces an
+			// invalid rule). Warn rather than reject -- a dest_addr holding
+			// ordinary resolvable domains is a legitimate Tor policy.
+			//
+			// History: these warnings were live from f532ad3 (2022-12-14) until
+			// d2aba93 (2024-02-16) 'better TOR support in nft', which deleted the
+			// dedicated policy_routing_tor_nft()/_iptables() helpers and folded
+			// Tor into policy_routing(). The call sites went with those helpers
+			// and were never re-added -- confirmed with the maintainer that this
+			// was unintentional rather than a deliberate removal. The catalog
+			// strings were left behind in pkg.uc and status.js, unreachable ever
+			// since. Deliberately not restored verbatim: the old
+			// warningTorUnsetParams also told users to unset src_addr, which that
+			// same refactor turned into the correct way to match a Tor policy, so
+			// its wording is now split per option.
+			//
+			// Deliberately NOT warned about: dest_addr, including '.onion'. A
+			// domain dest_addr is a supported Tor policy and works whenever DNS
+			// for the domain reaches Tor. pbr cannot see whether it does -- that
+			// depends on dnsmasq, which on OpenWrt declares '.onion' local via
+			// /usr/share/dnsmasq/rfc6761.conf -- so any such warning would fire
+			// just as loudly on a correct setup as on a broken one. Documented
+			// instead; see the Tor section of the README.
+			if (src_port)
+				push(state.warnings, { code: 'warningTorUnsetSrcPort', info: name });
+			if (dest_port)
+				push(state.warnings, { code: 'warningTorUnsetDestPort', info: name });
+			if (proto)
+				push(state.warnings, { code: 'warningTorUnsetProto', info: name });
+			if (chain && lc(chain) != 'prerouting')
+				push(state.warnings, { code: 'warningTorUnsetChainNft', info: name });
+		}
 		if (!net.is_supported_interface(interface_name) && !net.is_mwan4_strategy(interface_name)) {
 			push(state.errors, { code: 'errorPolicyUnknownInterface', info: name });
 			output.fail(); return 1;
@@ -2356,7 +2391,6 @@ function create_pbr(fs_mod, uci_mod, ubus_mod) {
 		result[name] = {
 			enabled: !!cfg.enabled,
 			running: platform.is_running_nft_file(),
-			running_iptables: false,
 			running_nft: nft.is_service_running_nft(),
 			running_nft_file: platform.is_running_nft_file(),
 			version: pkg.version,

--- a/files/lib/pbr/pkg.uc
+++ b/files/lib/pbr/pkg.uc
@@ -9,7 +9,7 @@
 const pkg = {
 	name: 'pbr',
 	version: 'dev-test',
-	compat: '35',
+	compat: '36',
 	config_file: '/etc/config/pbr',
 	debug_file: '/var/run/pbr.debug',
 	lock_file: '/var/run/pbr.lock',
@@ -111,7 +111,8 @@ function get_text(code, cfg, ...args) {
 		warningInvalidOVPNConfig:              sprintf("Invalid OpenVPN config for '%s' interface", a1),
 		warningResolverNotSupported:           sprintf("Resolver set (%s) is not supported on this system", cfg.resolver_set),
 		warningPolicyProcessCMD:               sprintf("'%s'", a1),
-		warningTorUnsetParams:                 sprintf("Please unset 'src_addr', 'src_port' and 'dest_port' for policy '%s'", a1),
+		warningTorUnsetSrcPort:                sprintf("Please unset 'src_port' for policy '%s': it produces an invalid rule", a1),
+		warningTorUnsetDestPort:               sprintf("Please unset 'dest_port' for policy '%s': it is ignored", a1),
 		warningTorUnsetProto:                  sprintf("Please unset 'proto' or set 'proto' to 'all' for policy '%s'", a1),
 		warningTorUnsetChainNft:               sprintf("Please unset 'chain' or set 'chain' to 'prerouting' for policy '%s'", a1),
 		warningOutdatedLuciPackage:            sprintf("The WebUI application is outdated (version %s), please update it", a1),

--- a/tests/04_policies/01_start_dynamic_routing
+++ b/tests/04_policies/01_start_dynamic_routing
@@ -9,7 +9,7 @@ let result = pbr.start_service(['on_start']);
 // result should be non-null (procd data)
 let checks = [
 	['result_not_null',    result != null],
-	['has_compat',         result.packageCompat == 35],
+	['has_compat',         result.packageCompat == 36],
 	['has_gateways',       type(result.gateways) == 'array'],
 	['has_errors',         type(result.errors) == 'array'],
 	['has_warnings',       type(result.warnings) == 'array'],

--- a/tests/04_policies/08_tor_policy_warnings
+++ b/tests/04_policies/08_tor_policy_warnings
@@ -1,0 +1,143 @@
+Testing that a Tor policy warns about the options pbr silently discards
+(src_port, dest_port, proto, chain). A dest_addr -- including '.onion' -- is a
+supported Tor policy and is deliberately NOT warned about: whether it works
+depends on DNS reaching Tor, which pbr cannot see, so a warning would fire on
+correct setups too. Such a policy must still build its set and stay silent.
+No policy is ever rejected.
+
+-- File uci/pbr.json --
+{
+	"pbr": [
+		{
+			".name": "config",
+			"enabled": "1",
+			"fw_mask": "00ff0000",
+			"ipv6_enabled": "0",
+			"resolver_set": "dnsmasq.nftset",
+			"uplink_interface": "wan",
+			"uplink_interface6": "wan6",
+			"uplink_ip_rules_priority": "30000",
+			"uplink_mark": "00010000",
+			"verbosity": "2",
+			"lan_device": ["br-lan"],
+			"resolver_instance": ["*"]
+		}
+	],
+	"policy": [
+		{
+			".name": "policy_tor_bad",
+			"name": "Tor Onion",
+			"enabled": "1",
+			"interface": "tor",
+			"src_addr": "192.168.1.50",
+			"dest_addr": "onion",
+			"src_port": "1024-65535",
+			"dest_port": "80 443",
+			"proto": "tcp",
+			"chain": "forward"
+		},
+		{
+			".name": "policy_tor_ok",
+			"name": "Tor Clean",
+			"enabled": "1",
+			"interface": "tor",
+			"src_addr": "192.168.1.51",
+			"dest_addr": "",
+			"src_port": "",
+			"dest_port": "",
+			"proto": "",
+			"chain": ""
+		},
+		{
+			".name": "policy_tor_normal",
+			"name": "Tor Normal Domain",
+			"enabled": "1",
+			"interface": "tor",
+			"src_addr": "192.168.1.52",
+			"dest_addr": "example.com",
+			"src_port": "",
+			"dest_port": "",
+			"proto": "",
+			"chain": ""
+		}
+	]
+}
+-- End --
+
+-- File fs/open~_etc_tor_torrc.txt --
+VirtualAddrNetwork 10.192.0.0/10
+AutomapHostsOnResolve 1
+TransPort 0.0.0.0:9040
+DNSPort 0.0.0.0:9053
+-- End --
+
+-- File fs/stat~_etc_tor_torrc.json --
+{ "type": "file", "size": 100 }
+-- End --
+
+-- File ubus/service~list~name-tor.json --
+{ "tor": { "instances": { "instance1": { "running": true } } } }
+-- End --
+
+-- Testcase --
+import create_pbr from 'pbr';
+let pbr = create_pbr();
+
+let result = pbr.start_service(['on_start']);
+let errors = map(result.errors || [], e => e.code);
+let nft = global.mocklib.read_captured('/var/run/pbr.nft') || '';
+
+// warnings carry the policy name in .info, so assert per policy
+function warned(code, who) {
+	for (let w in (result.warnings || []))
+		if (w.code == code && w.info == who) return true;
+	return false;
+}
+
+let checks = [
+	// 'Tor Onion' sets every discarded option -- each must be reported once
+	['warns_src_port',     warned('warningTorUnsetSrcPort', 'Tor Onion')],
+	['warns_dest_port',    warned('warningTorUnsetDestPort', 'Tor Onion')],
+	['warns_proto',        warned('warningTorUnsetProto', 'Tor Onion')],
+	['warns_chain',        warned('warningTorUnsetChainNft', 'Tor Onion')],
+	// 'Tor Clean' sets only src_addr -- it must not be warned about at all
+	['clean_no_src_port',  !warned('warningTorUnsetSrcPort', 'Tor Clean')],
+	['clean_no_dest_port', !warned('warningTorUnsetDestPort', 'Tor Clean')],
+	['clean_no_proto',     !warned('warningTorUnsetProto', 'Tor Clean')],
+	['clean_no_chain',     !warned('warningTorUnsetChainNft', 'Tor Clean')],
+	// A domain dest_addr is a supported Tor policy: it must still be processed
+	// into its own nftset, and must not be warned about at all. dest_addr is
+	// deliberately not warned on -- pbr cannot tell a working DNS setup from a
+	// broken one, so the warning would fire on both.
+	['normal_set_built',   index(nft, 'pbr_tor_4_dst_ip_policy_tor_normal') >= 0],
+	['normal_no_warnings', length(filter(result.warnings || [], w => w.info == 'Tor Normal Domain')) == 0],
+	// Tor has no device, gateway, routing table or mark, and must never be
+	// reported as missing one. It is registered by interface_process.tor()
+	// rather than the foreach('network','interface') loop, so it never reaches
+	// get_gateway4()/get_gateway6() -- which is structural, not asserted
+	// anywhere else. Guards against Tor being folded into the main interface
+	// loop, or a registry sweep being added, either of which would emit
+	// warnings for fields Tor cannot have.
+	['tor_no_gw_warning',  length(filter(result.warnings || [], w =>
+		(w.code == 'warningInterfaceRoutingUnknownGateway4' ||
+		 w.code == 'warningInterfaceRoutingUnknownGateway6') &&
+		index('' + w.info, 'tor') >= 0)) == 0],
+	// warnings only -- no policy is rejected
+	['not_rejected',       index(errors, 'errorPolicyUnknownInterface') < 0],
+];
+
+let pass = 0, fail = 0;
+for (let c in checks) {
+	if (c[1]) {
+		pass++;
+	} else {
+		fail++;
+		printf("FAIL: %s\n", c[0]);
+	}
+}
+printf("tor_policy_warnings: %d/%d passed\n", pass, pass + fail);
+-- End --
+
+-- Expect stdout --
+tor_policy_warnings: 12/12 passed
+-- End --


### PR DESCRIPTION
## What

A Tor policy silently discards several of the options a user can set on it, and one of them makes the emitted ruleset invalid. Nothing said so — the policy loaded without error and the rules looked plausible in `nft list`.

Tor is a dstnat redirect rather than a routed interface. `policy_routing()` forces the `dstnat` chain, clears `dest_port` and `proto`, and emits five rules hardcoding ports 53/80/443. So `dest_port`, `proto` and a non-`prerouting` `chain` are thrown away. `src_port` is worse than ignored: it survives into the rule, the now-empty `proto` is promoted to `tcp udp` because a port is set, and the result matches `tcp sport ... udp dport ...` — conflicting L4 protocols, which nft rejects.

This warns on all four. Warn and continue; nothing is rejected.

## Why they were missing

Warnings for exactly this were live between `f532ad3` (2022-12-14) and `d2aba93` (2024-02-16). That commit, *"better TOR support in nft"*, deleted the dedicated `policy_routing_tor_nft()`/`_iptables()` helpers and folded Tor into `policy_routing()`; the warning call sites lived inside those helpers and went with them. Confirmed unintentional rather than a deliberate removal.

The catalog strings were left behind in both repos and have been unreachable ever since — the WebUI has carried render entries for warnings that could never fire for over two years.

`warningTorUnsetParams` is **not** restored verbatim. It also told users to unset `src_addr`, which that same 2024 refactor turned into the correct way to match a Tor policy — so restoring it as-is would now be wrong advice. Split into `warningTorUnsetSrcPort` and `warningTorUnsetDestPort`, which also lets each carry its real consequence.

## Deliberately not warned about: `dest_addr`

A domain `dest_addr`, including `.onion`, is a supported Tor policy and works whenever DNS for that domain reaches Tor. pbr cannot observe whether it does — that depends on dnsmasq, which on OpenWrt declares `.onion` local through `/usr/share/dnsmasq/rfc6761.conf` and answers NXDOMAIN itself, overriding any `server=/onion/127.0.0.1#9053`. A warning there would fire exactly as loudly on a correct setup as on a broken one, so it is documented rather than warned about.

## Also

Drops the hardcoded `running_iptables: false` from the status payload. It has been unconditionally false since the iptables backend was removed in 1.1.7, and its only consumers were two dead branches in luci-app-pbr, removed in the companion PR.

## Testing

47/47 pass. New test `tests/04_policies/08_tor_policy_warnings` covers three Tor policies — one setting every discarded option, one setting only `src_addr`, one with an ordinary domain `dest_addr` — with 12 checks:

- each warning fires where it should, and none where it should not
- a domain `dest_addr` still builds its nftset and stays silent
- no policy is rejected
- Tor never reports an unknown gateway

That last check guards behaviour that is currently structural rather than asserted: Tor is registered by `interface_process.tor()` rather than the `foreach('network','interface')` loop, so it never reaches `get_gateway4()`/`get_gateway6()` and never warns about the device, gateway, table or mark it cannot have. Verified by mutation — injecting such a warning fails the test.

## ⚠️ Merge together with luci-app-pbr#39

These two are a matched pair. **mossdef-org/luci-app-pbr#39** carries the WebUI strings for the two new warning codes and the matching compat bump. Merging either alone leaves a compat mismatch — users would see the version-mismatch warning until both are in, and any warning fired by this PR would render as "Unknown warning".

## Follow-ups, not included here

- pbr reads only `/etc/tor/torrc`. OpenWrt's own Tor client guide writes its config to `/etc/tor/custom` and includes it via `tor.conf.tail_include`, so anyone following the official guide has DNSPort/TransPort values pbr never sees. It works today only because that guide uses 9053/9040 — the same numbers as pbr's fallback.
- The port parse accepts only the `address:port` form. A bare `DNSPort 9153` falls back to 9053 silently. Worth doing with the item above — widening the regex alone helps nobody whose config pbr is not reading.
- Only `udp dport 53` is redirected; there is no `tcp dport 53` rule, in 1.2.3 or 1.2.2. TCP DNS bypasses Tor entirely.
- In the Tor branch, `ipv4_error`/`ipv6_error` are tested inside the `tor_rules` loop and never reset, so one failed insertion is reported up to five times.
- `interface_process.tor('destroy')` is a no-op; the switch handles only create/reload/reload_interface.
- `tests/run_tests.sh` applies `sed '/get_rt_tables_id/,/^};/ s/m\[1\]/m[2]/'` to the patched `pbr.uc`. No line after that match starts with `};` at column 0, so the range runs to EOF and rewrites every `m[1]` in the tail, including both Tor port helpers — any test covering the Tor ports reads as broken (`:null`) even when the code is correct. This blocks tests for the two torrc items above, so it is worth fixing first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
