### PR TITLE
pbr-1.2.3: bump PKG_RELEASE from 83 to 85

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=pbr
 PKG_VERSION:=1.2.3
-PKG_RELEASE:=83
+PKG_RELEASE:=85
 PKG_LICENSE:=AGPL-3.0-or-later
 PKG_MAINTAINER:=Stan Grishin <stangri@melmac.ca>, Erik Conijn <egc112@msn.com>
 


### PR DESCRIPTION
### What's new in release 85

**Tor policies now tell you when a setting is being ignored.**
If you set a source port, destination port, protocol, or a chain other than prerouting on a Tor policy, pbr quietly threw it away — and a source port silently produced a rule the firewall rejects. These warnings existed years ago and were lost in a 2024 refactor. They're back, now one warning per option so each says what actually happens to your setting. Nothing is rejected; you're just told. A domain or `.onion` destination address is still supported and deliberately stays silent.

**Routers with very many interfaces no longer collide with the kernel's own routing rule.**
Once the IP rule priority counter ran out — roughly 98 or more enabled interfaces — pbr would add a rule at priority 0, on top of the kernel's own `from all lookup local`, then keep counting into negative numbers. It now skips that interface and reports "interface priority exhausted" in the WebUI, matching how firewall mark overflow already behaved.

**WebUI cleanup.** Leftover strings and code paths from the old iptables backend, gone since pbr 1.1.7, have been removed. Nothing changes on screen — every removed branch was already unreachable.

**Packaging.** The version-check script was renamed `test.sh` → `test-version.sh` to match the OpenWrt packages feed. No effect on the installed package.

**⚠️ Update both packages together.** The compatibility number moved 34 → 36 in this release. If only one is updated, the WebUI reports a version mismatch and tells you to update.

---

**pbr commits since 83:** #149 priority-exhaustion guard · #150 Tor policy warnings · #152 `test-version.sh` rename
**luci-app-pbr commits since 83:** mossdef-org/luci-app-pbr#37 `errorInterfacePriorityExhausted` · mossdef-org/luci-app-pbr#39 Tor warning strings + iptables cleanup

Pairs with the luci-app-pbr bump to 85; both should land together.
