### PR TITLE
pbr-1.2.2: bump PKG_RELEASE from 20 to 22

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=pbr
 PKG_VERSION:=1.2.2
-PKG_RELEASE:=20
+PKG_RELEASE:=22
 PKG_LICENSE:=AGPL-3.0-or-later
 PKG_MAINTAINER:=Stan Grishin <stangri@melmac.ca>, Erik Conijn <egc112@msn.com>
 


### PR DESCRIPTION
### What's new in release 22

**Fixed: pbr could knock out LAN forwarding and port forwards.**
When rebuilding its rules, pbr flushed the firewall's own `forward`, `dstnat`, `prerouting` and `output` chains instead of its own — wiping fw4's zone jumps and port forwards. Normally a reload seconds later papered over it, but if that reload was skipped because the new ruleset failed validation, the outage stayed. Since `forward`'s default policy is drop, that meant no LAN↔WAN traffic at all. Backport of the fix already in 1.2.3.

**Fixed: custom script paths no longer rewritten on upgrade.**
Scripts kept in `/etc/pbr/` had their paths silently rewritten to `/usr/share/pbr/` on every upgrade, so after a sysupgrade they stopped being found. (#130)

**IPsec/xfrm interfaces are now recognised.** They count as tunnel interfaces like WireGuard and OpenVPN, and point-to-point detection is now done the same way everywhere — so no more spurious "unknown gateway" warnings on those interfaces.

**Fixed in the WebUI: your resolver set choice is no longer lost when you hit Save.**
Only affects LuCI master/snapshot builds at the moment — stable releases do not yet carry the luci-base change that triggers it, so on 24.10 and 25.12 you are unaffected. On master, the first Save on the overview page deleted the provisioned `resolver_set` value, silently turning resolver set support off while the WebUI still showed it enabled, and domain policies quietly fell back to one-off lookups. On 1.2.2 nothing restored it afterwards, so it stayed off. This fix lands ahead of that change reaching stable. Thanks to @pesa1234 for spotting it.

**Release/packaging.** apk files keep their `r` release prefix so downloads match locally built ones, stale release assets are pruned, the SDK is pinned to stable point releases, and new releases now sync to repo.mossdef.org immediately instead of waiting for the hourly poll.

The compatibility number is unchanged at 27 — nothing since release 20 touched the message catalog, so no forced pairing this time. Both packages are released together as usual.

---

**pbr commits since 20:** #131 `/etc/pbr/` path rewrite (fixes #130) · #140 xfrm/IPsec interface support · #145 fw4 chain flush fix · maintainer metadata
**luci-app-pbr commits since 20:** mossdef-org/luci-app-pbr#38 resolver_set preserved on save · release workflow and packaging fixes · maintainer metadata

Pairs with the luci-app-pbr 1.2.2 bump to 22; both should land together.
