### PR TITLE
pbr-1.2.3: record system() calls in mocklib, guard three regressions

### DIFF
--- a/tests/01_validation/04_mocklib_system_recorder
+++ b/tests/01_validation/04_mocklib_system_recorder
@@ -1,0 +1,83 @@
+Testing the mocklib system() recorder itself. mocklib.commands() must return
+every command system() was called with, in call order, optionally filtered by
+substring or regexp, and as a copy the caller cannot disturb; has_command()
+mirrors it as a boolean; clear_commands() resets the recording so a test can
+assert on one phase at a time.
+
+The second half runs a real start_service() to show the recorder sees the
+calls that leave no other trace: the nft chain flushes issued through
+sh.run() and the 'ip rule del' loops that call system() directly. Neither
+appears in /var/run/pbr.nft nor in the start_service() result, so before this
+recorder existed there was no way to assert on them at all.
+
+-- Testcase --
+import create_pbr from 'pbr';
+
+let mocklib = global.mocklib;
+
+// ── the recorder API on its own ─────────────────────────────────────
+mocklib.clear_commands();
+let empty = mocklib.commands();
+
+system('/usr/libexec/ip-full -4 rule del priority 0 2>/dev/null');
+system('nft flush chain inet fw4 pbr_forward >/dev/null 2>&1');
+system(['/usr/libexec/ip-full', '-6', 'rule', 'del', 'priority', '0']);
+
+let all = mocklib.commands();
+let substring_hits = mocklib.commands('rule del priority 0');
+let regexp_hits = mocklib.commands(/^nft /);
+
+// mutating what commands() handed back must not disturb the recording
+let copy = mocklib.commands();
+push(copy, 'never executed');
+
+let checks = [
+	['clear_empties',        length(empty) == 0],
+	['records_every_call',   length(all) == 3],
+	['records_in_order',     index(all[0], '-4 rule del') >= 0 &&
+	                         index(all[1], 'nft flush') >= 0],
+	['array_argv_joined',    all[2] == '/usr/libexec/ip-full -6 rule del priority 0'],
+	['substring_filter',     length(substring_hits) == 2],
+	['regexp_filter',        length(regexp_hits) == 1 &&
+	                         index(regexp_hits[0], 'pbr_forward') >= 0],
+	['returns_a_copy',       length(mocklib.commands()) == 3],
+	['has_command_true',     mocklib.has_command('nft flush chain')],
+	['has_command_false',    !mocklib.has_command('fw4 -q reload')],
+	['has_command_regexp',   mocklib.has_command(/rule del priority 0$/)],
+];
+
+// ── the same recorder over a real start ─────────────────────────────
+mocklib.clear_commands();
+
+let pbr = create_pbr();
+pbr.start_service(['on_start']);
+
+let flushes = mocklib.commands(/^nft flush chain /);
+let bare_flushes = filter(flushes, cmd =>
+	match(cmd, /fw4 (forward|output|prerouting|dstnat) /));
+
+push(checks,
+	// everything system() sees is recorded, including the tty probe
+	['tty_probe_recorded',   mocklib.has_command('[ -t ')],
+	// the item this unblocks: pbr_-prefixed chains only, never fw4's own
+	['pbr_chains_flushed',   length(flushes) == 4],
+	['bare_chains_kept',     length(bare_flushes) == 0],
+	// and the ip rule deletes, which go to system() directly
+	['rule_delete_recorded', mocklib.has_command('rule del priority 30000')],
+	['no_priority_zero_del', !mocklib.has_command(/rule del priority 0 /)]);
+
+let pass = 0, fail = 0;
+for (let c in checks) {
+	if (c[1]) {
+		pass++;
+	} else {
+		fail++;
+		printf("FAIL: %s\n", c[0]);
+	}
+}
+printf("mocklib_system_recorder: %d/%d passed\n", pass, pass + fail);
+-- End --
+
+-- Expect stdout --
+mocklib_system_recorder: 15/15 passed
+-- End --

--- a/tests/03_nft_rules/05_main_chains_flush_prefix
+++ b/tests/03_nft_rules/05_main_chains_flush_prefix
@@ -1,0 +1,63 @@
+Testing that nft.cleanup()'s 'main_chains' case flushes pbr's own prefixed
+chains and never fw4's base chains.
+
+Regression guard for bd042da (#143): the case flushed bare 'forward' /
+'output' / 'prerouting' / 'dstnat' instead of 'pbr_forward' and friends, so
+every start wiped fw4's own base chains -- taking down LAN<->WAN forwarding
+and every NAT port forward on the router until fw4 was reloaded.
+
+The flush goes through nft_call() -> sh.run() -> system(), so it leaves no
+trace in /var/run/pbr.nft; this asserts on the recorded system() calls
+instead. pkg.chains_list is 'forward output prerouting' and cleanup() appends
+'dstnat', so a correct start flushes exactly four chains, all prefixed.
+
+-- Testcase --
+import create_pbr from 'pbr';
+
+let mocklib = global.mocklib;
+
+mocklib.clear_commands();
+
+let pbr = create_pbr();
+pbr.start_service(['on_start']);
+
+let flushes = mocklib.commands(/^nft flush chain /);
+
+// fw4's own base chains -- 'inet fw4 forward', not 'inet fw4 pbr_forward'
+let bare_flushes = filter(flushes, cmd =>
+	match(cmd, /inet fw4 (forward|output|prerouting|dstnat)( |$)/));
+
+let prefixed = filter(flushes, cmd => match(cmd, /inet fw4 pbr_/));
+
+let flushed = (chain) => length(filter(flushes,
+	cmd => match(cmd, regexp('inet fw4 ' + chain + '( |$)')))) == 1;
+
+let checks = [
+	['four_chains_flushed',  length(flushes) == 4],
+	['all_prefixed',         length(prefixed) == 4],
+	['no_bare_chain_flush',  length(bare_flushes) == 0],
+	['pbr_forward',          flushed('pbr_forward')],
+	['pbr_output',           flushed('pbr_output')],
+	['pbr_prerouting',       flushed('pbr_prerouting')],
+	['pbr_dstnat',           flushed('pbr_dstnat')],
+	// flushing the table itself would take fw4 down just as thoroughly
+	['no_table_flush',       !mocklib.has_command(/^nft flush table /)],
+	// and the chains are flushed, never deleted -- fw4 owns their definitions
+	['no_chain_delete',      !mocklib.has_command(/^nft delete chain inet fw4 pbr_(forward|output|prerouting|dstnat)( |$)/)],
+];
+
+let pass = 0, fail = 0;
+for (let c in checks) {
+	if (c[1]) {
+		pass++;
+	} else {
+		fail++;
+		printf("FAIL: %s\n", c[0]);
+	}
+}
+printf("main_chains_flush_prefix: %d/%d passed\n", pass, pass + fail);
+-- End --
+
+-- Expect stdout --
+main_chains_flush_prefix: 9/9 passed
+-- End --

--- a/tests/03_nft_rules/06_prio_min_floor
+++ b/tests/03_nft_rules/06_prio_min_floor
@@ -1,0 +1,114 @@
+Testing that nft.cleanup()'s 'main_table' delete window never reaches IP rule
+priority 0.
+
+Regression guard for 12b9937, the router-bricking one. The window runs from
+uplink_ip_rules_priority + 1 down to uplink_ip_rules_priority - (fw_mask /
+uplink_mark), and every rule inside it is deleted. With a widened mask that
+lower bound goes negative, so the window swallows priority 0 -- the kernel's
+own 'from all lookup local' rule. Deleting it kills local delivery: the router
+stops answering on its own addresses and needs a physical reset.
+
+This config is the one from the fix's own comment: uplink_ip_rules_priority=99
+(the clamp floor) with fw_mask=ffff0000 and uplink_mark=00010000, so
+max_ifaces is 65535 and the unclamped lower bound would be -65436. The floor
+at files/lib/pbr/nft.uc:643 pins it to 1, which guards both the v4 and the v6
+loop since each tests 'prio < prio_min'.
+
+The deletes go straight to system(), so they leave no trace in
+/var/run/pbr.nft; this asserts on the recorded system() calls instead. The
+'ip rule show' fixtures below are what the loops iterate over -- priority 0 is
+present in both, exactly as it is on a real router.
+
+-- File fs/popen~_usr_libexec_ip-full_-4_rule_show_2_dev_null.txt --
+0:	from all lookup local
+99:	from all lookup pbr_wan
+100:	from all lookup main suppress_prefixlength 1
+32766:	from all lookup main
+32767:	from all lookup default
+-- End --
+
+-- File fs/popen~_usr_libexec_ip-full_-6_rule_show_2_dev_null.txt --
+0:	from all lookup local
+99:	from all lookup pbr_wan
+100:	from all lookup main suppress_prefixlength 1
+32766:	from all lookup main
+-- End --
+
+-- File uci/pbr.json --
+{
+	"pbr": [
+		{
+			".name": "config",
+			"enabled": "1",
+			"fw_mask": "ffff0000",
+			"ipv6_enabled": "1",
+			"prefixlength": "1",
+			"resolver_set": "dnsmasq.nftset",
+			"strict_enforcement": "1",
+			"uplink_interface": "wan",
+			"uplink_interface6": "wan6",
+			"uplink_ip_rules_priority": "99",
+			"uplink_mark": "00010000",
+			"verbosity": "2",
+			"lan_device": ["br-lan"],
+			"resolver_instance": ["*"],
+			"debug_performance": "0"
+		}
+	],
+	"policy": [],
+	"dns_policy": [],
+	"include": []
+}
+-- End --
+
+-- Testcase --
+import create_pbr from 'pbr';
+
+let mocklib = global.mocklib;
+
+mocklib.clear_commands();
+
+let pbr = create_pbr();
+pbr.start_service(['on_start']);
+
+let deletes = mocklib.commands(/rule del priority /);
+
+let checks = [
+	// the guard itself -- both families, both loops
+	['no_v4_priority_zero',   !mocklib.has_command('-4 rule del priority 0 ')],
+	['no_v6_priority_zero',   !mocklib.has_command('-6 rule del priority 0 ')],
+	['no_negative_priority',  !mocklib.has_command(/rule del priority -/)],
+	// the window still does its job, or the checks above would pass vacuously
+	['v4_in_window_deleted',   mocklib.has_command('-4 rule del priority 99 ')],
+	['v6_in_window_deleted',   mocklib.has_command('-6 rule del priority 99 ')],
+	['v4_prio_max_deleted',    mocklib.has_command('-4 rule del priority 100 ')],
+	// and stays inside its bounds at the top end
+	['above_window_kept',     !mocklib.has_command('rule del priority 32766')],
+	['default_rule_kept',     !mocklib.has_command('rule del priority 32767')],
+	// the unconditional suppress_prefixlength deletes are unaffected
+	['v4_suppress_deleted',    mocklib.has_command('-4 rule del lookup main suppress_prefixlength 1')],
+	['v6_suppress_deleted',    mocklib.has_command('-6 rule del lookup main suppress_prefixlength 1')],
+	// the invariant behind all of the above, over every delete pbr issues --
+	// the cleanup window and the per-interface deletes alike
+	['all_priorities_positive',
+		length(filter(map(deletes, d => {
+			let m = match(d, /priority (-?\d+)/);
+			return m ? +m[1] : 1;
+		}), prio => prio <= 0)) == 0],
+];
+
+let pass = 0, fail = 0;
+for (let c in checks) {
+	if (c[1]) {
+		pass++;
+	} else {
+		fail++;
+		printf("FAIL: %s\n", c[0]);
+	}
+}
+printf("prio_min_floor: %d/%d passed\n", pass, pass + fail);
+-- End --
+
+-- Expect stdout --
+prio_min_floor: 11/11 passed
+-- End --

--- a/tests/03_nft_rules/07_mwan4_chains_survive_stop
+++ b/tests/03_nft_rules/07_mwan4_chains_survive_stop
@@ -1,0 +1,114 @@
+Testing that stopping pbr leaves mwan4's chains alone.
+
+The README promises pbr and mwan4 can share a router, and stop_service() only
+cleans up what pbr owns: it removes its own nft file and calls
+nft.cleanup('main_table', 'rt_tables') -- no chain teardown at all. Nothing
+asserted that. 04_policies/07_policy_mwan4_strategy covers strategy targeting
+only and never calls stop_service.
+
+Teardown is nft calls and 'ip rule del' calls, not a written ruleset, so there
+is nothing to read back from /var/run/pbr.nft; this asserts on the recorded
+system() calls instead. The guard is deliberately phrased around what pbr may
+touch -- its own pbr_-prefixed chains -- rather than freezing today's exact
+teardown, so a future change that does clean pbr's chains still passes, while
+one that reaches mwan4's chains or fw4's base chains fails.
+
+-- File fs/access~_etc_init_d_mwan4~x.txt --
+true
+-- End --
+
+-- File fs/stat~_etc_config_mwan4.json --
+{"type":"file"}
+-- End --
+
+-- File fs/popen~_usr_libexec_ip-full_-4_rule_show_2_dev_null.txt --
+0:	from all lookup local
+2001:	from all fwmark 0x100/0x3f00 lookup mwan4_iface_wan
+29999:	from all lookup pbr_vpn
+30000:	from all lookup main suppress_prefixlength 1
+32766:	from all lookup main
+32767:	from all lookup default
+-- End --
+
+-- File fs/popen~nft_list_table_inet_fw4_2_dev_null.txt --
+table inet fw4 {
+	chain forward {
+		type filter hook forward priority filter; policy drop;
+	}
+
+	chain mwan4_hook {
+		jump mwan4_iface_in_wan
+	}
+
+	chain mwan4_iface_in_wan {
+		meta mark set 0x00000100
+	}
+
+	chain mwan4_strategy_balanced {
+		meta nfproto ipv4 jump mwan4_strategy_balanced_ipv4
+	}
+
+	chain pbr_mark_wan {
+		meta mark set 0x00010000
+	}
+
+	chain pbr_mark_vpn {
+		meta mark set 0x00020000
+	}
+
+	chain pbr_forward {
+		jump pbr_mark_wan
+	}
+}
+-- End --
+
+-- Testcase --
+import create_pbr from 'pbr';
+
+let mocklib = global.mocklib;
+
+let pbr = create_pbr();
+pbr.start_service(['on_start']);
+
+// record the teardown only
+mocklib.clear_commands();
+pbr.stop_service();
+
+let stop_commands = mocklib.commands();
+let chain_ops = mocklib.commands(/^nft (delete|flush) chain /);
+let foreign_chain_ops = filter(chain_ops, cmd => !match(cmd, /inet fw4 pbr_/));
+
+let checks = [
+	// the stop actually ran, or everything below passes vacuously
+	['stop_ran',            length(stop_commands) > 0],
+	['fw4_reloaded',        mocklib.has_command('fw4 -q reload')],
+	['route_cache_flushed', mocklib.has_command('route flush cache')],
+	['rt_tables_synced',    mocklib.has_command('sync')],
+	['pbr_rules_removed',   mocklib.has_command('-4 rule del priority 29999')],
+	// the promise: nothing pbr does on stop goes near mwan4 -- not its chains,
+	// and not the ip rules it parks well below pbr's cleanup window either
+	['mwan4_untouched',     !mocklib.has_command('mwan4')],
+	['mwan4_ip_rule_kept',  !mocklib.has_command('rule del priority 2001')],
+	['kernel_local_kept',   !mocklib.has_command('rule del priority 0 ')],
+	['no_foreign_chain_op', length(foreign_chain_ops) == 0],
+	// fw4's own chains are not pbr's to tear down either
+	['fw4_base_chains_kept',
+		!mocklib.has_command(/inet fw4 (forward|output|prerouting|dstnat)( |$)/)],
+	['no_table_teardown',   !mocklib.has_command(/^nft (delete|flush) table /)],
+];
+
+let pass = 0, fail = 0;
+for (let c in checks) {
+	if (c[1]) {
+		pass++;
+	} else {
+		fail++;
+		printf("FAIL: %s\n", c[0]);
+	}
+}
+printf("mwan4_chains_survive_stop: %d/%d passed\n", pass, pass + fail);
+-- End --
+
+-- Expect stdout --
+mwan4_chains_survive_stop: 11/11 passed
+-- End --

--- a/tests/lib/mocklib.uc
+++ b/tests/lib/mocklib.uc
@@ -164,6 +164,21 @@ let trace_call = (ns, func, args) => {
 /* Captured file contents from mock writefile — used for readfile/writefile round-trip */
 let _captured = {};
 
+/* Commands passed to system() — used by tests to assert on what was executed */
+let _commands = [];
+
+/* Select recorded commands: everything when needle is null, those containing
+   needle when it is a string, those matching it when it is a regexp. */
+let commands_matching = (needle) => {
+	if (needle == null)
+		return slice(_commands);
+
+	if (type(needle) == "regexp")
+		return filter(_commands, cmd => match(cmd, needle));
+
+	return filter(_commands, cmd => index(cmd, '' + needle) >= 0);
+};
+
 /* Prepend mocklib to REQUIRE_SEARCH_PATH */
 for (let pattern in REQUIRE_SEARCH_PATH) {
 	/* Only consider ucode includes */
@@ -231,11 +246,33 @@ global.mocklib = {
 
 	/* Remove a path from the captured map */
 	delete_captured: (path) => { delete _captured[path]; },
+
+	/* Read the commands system() was called with, in call order (called by
+	   tests to inspect commands that are executed rather than written out).
+	   Returns a copy, so the caller cannot disturb the recording.
+
+	   Pass nothing for the full list, a string to keep only the commands
+	   containing it, or a regexp to keep only the ones matching it. Note
+	   sh.run() appends ' >/dev/null 2>&1' to everything it runs, so match on
+	   substrings or anchored regexps rather than on equality. */
+	commands: commands_matching,
+
+	/* Check whether any recorded command matches — same argument as commands() */
+	has_command: (needle) => length(commands_matching(needle)) > 0,
+
+	/* Drop everything recorded so far, so a test can record one phase at a
+	   time (e.g. clear after start_service() to assert on stop_service()) */
+	clear_commands: () => { _commands = []; },
 };
 
 /* Override stdlib functions */
 global.system = function(argv, timeout) {
 	trace_call(null, "system", { command: argv, timeout });
+
+	/* Record the command for mocklib.commands(). Everything is recorded,
+	   including the '[ -t 2 ]' tty probe below, so the list reflects the
+	   process exactly as it ran. */
+	push(_commands, type(argv) == "array" ? join(' ', argv) : '' + argv);
 
 	/* Return 1 for tty checks so output goes to logger, not stderr */
 	if (type(argv) == "string" && index(argv, "[ -t ") >= 0)

--- a/tests/lib/mocklib.uc
+++ b/tests/lib/mocklib.uc
@@ -164,7 +164,10 @@ let trace_call = (ns, func, args) => {
 /* Captured file contents from mock writefile — used for readfile/writefile round-trip */
 let _captured = {};
 
-/* Commands passed to system() — used by tests to assert on what was executed */
+/* Commands passed to system() — used by tests to assert on what was executed.
+   run_tests.sh spawns one ucode process per testcase, so this starts empty for
+   each and cannot leak into the next; clear_commands() is for asserting a single
+   phase within one run, not for cleaning up after another test. */
 let _commands = [];
 
 /* Select recorded commands: everything when needle is null, those containing


### PR DESCRIPTION
Test infrastructure only — nothing under `files/` is touched, and `tests/` is not shipped in the package, so this needs no `PKG_RELEASE` bump and no `luci-app-pbr` counterpart.

pbr issues much of its effect through `system()`: `nft_call()` runs `nft ...` via `sh.run()`, and the ip rule cleanup loops call `system()` directly. The mock in `tests/lib/mocklib.uc` traced those calls to the debug log and dropped them, so no testcase could ever see them — leaving chain flushes, rule deletions and teardown ordering untestable, and three shipped regressions without a guard.

## `tests: record system() calls in mocklib`

Records every command the mock is handed and exposes it next to the existing capture helpers:

```
mocklib.commands()             every command, in call order, as a copy
mocklib.commands('substring')  only the ones containing it
mocklib.commands(/regexp/)     only the ones matching it
mocklib.has_command(needle)    the same selection, as a boolean
mocklib.clear_commands()       drop the recording, to assert one phase
```

Array argv is joined with spaces before recording and nothing is filtered out, including the `[ -t 2 ]` tty probe, so the list reflects the process as it ran. `sh.run()` appends ` >/dev/null 2>&1` to everything, so testcases match on substrings or anchored regexps rather than equality. Additive: no existing mocklib behavior changes.

The accompanying testcase covers the API itself, then asserts over a real `start_service()` run — which doubles as end-to-end proof that the recorder sees calls leaving no other trace.

## Three guards it unlocks

**`tests: guard nft cleanup against flushing fw4's base chains`** — regression guard for #143 (`bd042da`). `cleanup()`'s `'main_chains'` case flushed bare `forward` / `output` / `prerouting` / `dstnat` instead of the `pbr_`-prefixed chains, so every start flushed fw4's own base chains, taking down LAN↔WAN forwarding and every NAT port forward until fw4 was reloaded. The fix went in unguarded — nothing in the suite matched flush against chain names. Asserts a start flushes exactly the four `pbr_`-prefixed chains and never a bare one, never flushes the table, and flushes rather than deletes, since fw4 owns their definitions.

**`tests: guard the ip rule cleanup window against priority 0`** — regression guard for `12b9937`. `cleanup()`'s `'main_table'` window runs from `uplink_ip_rules_priority + 1` down to `uplink_ip_rules_priority - (fw_mask / uplink_mark)`. With a widened mask that lower bound goes negative and the window swallows priority 0 — the kernel's own `from all lookup local` rule. Deleting it kills local delivery: the router stops answering on its own addresses and needs a physical reset. Uses the config from the fix's own comment (`uplink_ip_rules_priority` 99, `fw_mask` ffff0000, unclamped bound −65436).

**`tests: assert mwan4 survives a pbr stop`** — the README promises pbr and mwan4 can share a router, but `04_policies/07_policy_mwan4_strategy` covers strategy targeting only and never calls `stop_service`, so nothing asserted that teardown leaves mwan4 alone. Runs a full start then a stop with mwan4 installed, and asserts the stop touches neither its chains nor its ip rules, that no chain operation reaches a chain pbr does not own, and that fw4's base chains and the table survive. Phrased around what pbr *may* touch rather than today's exact teardown, so a future change that does clean pbr's own chains on stop still passes.

## Verification

Each guard was checked against a simulated regression, not just against passing code:

- base-chains guard: reintroducing the unprefixed flush fails the relevant checks
- priority-0 guard: dropping the clamp floor fails 3 of 11 checks, including both priority-0 deletes
- mwan4 guard: sweeping mark chains without the `pbr_mark_` prefix filter and adding `'marking_chains'` to the stop cleanup fails 3 of 11 checks

Suite is 51/51 on this branch.
