### PR TITLE
pbr-1.2.3: bump PKG_RELEASE from 85 to 87

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=pbr
 PKG_VERSION:=1.2.3
-PKG_RELEASE:=85
+PKG_RELEASE:=87
 PKG_LICENSE:=AGPL-3.0-or-later
 PKG_MAINTAINER:=Stan Grishin <stangri@melmac.ca>, Erik Conijn <egc112@msn.com>
 


### PR DESCRIPTION
### What's new in release 87

**Domain-based policies no longer break for a moment every time pbr reloads.**
Whenever pbr reloaded, it deleted the address lists that dnsmasq writes resolved domains into, then spent the rest of the reload rebuilding them. For that stretch — measured at about 0.85 seconds on a four-interface router, around two seconds on one with ten — the lists simply did not exist, while dnsmasq carried on answering queries. Anything looked up in that gap logged `nftset ... Error: No such file or directory` in the system log, and, more importantly, that address was never added to the policy at all. The site kept using the wrong connection until something looked the name up again. pbr now leaves the lists alone and lets the firewall reload swap them in, so there is no gap to fall into.

**Domains you have already visited keep working across a reload.**
This follows from the same change. Previously every reload emptied those address lists, so after a reload a domain policy only started working again once each site was looked up afresh — and if your router had the answer cached, that could take minutes or hours. The lists now survive a reload with their contents intact, and so does a stop followed by a start.

**Faster recovery after you change a policy.**
When pbr reloads without any change to its DNS settings, it now clears the router's DNS cache. Without that, a domain answered from cache never reaches the policy's address list, and the policy can look dead until the cached entry expires. Clearing the cache is instant and does not interrupt DNS — no queries are dropped and the service is not restarted. The only visible effect is that the first lookup of each name after a reload goes out to your DNS provider rather than being answered locally.

**Worth knowing:** because addresses now persist rather than being cleared each reload, a domain that changes its address keeps the old one until it expires. Entries only expire if you have set a set timeout or garbage-collection interval in pbr's advanced settings; left unset, they stay. If you route a domain that moves around a lot, setting a timeout is worth considering.

**Both packages are released together as usual,** but the compatibility number is unchanged at 36 in this release, so there is no version-mismatch warning and nothing breaks if one is updated before the other.

---

**pbr commits since 85:** #155 nft set reload window · #156 mocklib `system()` recorder and three regression guards (tests only, not shipped)
**luci-app-pbr commits since 85:** none — bumped to stay in lockstep

Pairs with the luci-app-pbr bump to 87; both should land together.
