### PR TITLE
pbr-1.2.3: empty a resolver set when its policy's domain list changes

### DIFF
--- a/files/lib/pbr/nft.uc
+++ b/files/lib/pbr/nft.uc
@@ -21,6 +21,11 @@ function create_nft(fs_mod, config, sh, output, pkg, platform, network, V, state
 	let nft_fw4_dump = '';
 	let resolver_working_flag = false;
 	let resolver_stored_hash = '';
+	// Per-set domain lists as of the previous generation of the dnsmasq file,
+	// snapshotted by store_hash() before configure() truncates it. Null means
+	// "no previous generation seen", which is deliberately not the same as
+	// "empty" -- see resolver.flush_changed().
+	let resolver_prev_domains = null;
 	let dnsmasq_ubus = null;
 
 	// Forward declaration (circular: resolveip_to_nftset → resolver → nftset → resolveip_to_nftset)
@@ -433,6 +438,35 @@ function create_nft(fs_mod, config, sh, output, pkg, platform, network, V, state
 		return false;
 	};
 
+	// Map each nft set named in a dnsmasq config to the domains routed into it,
+	// as 'domain,domain' sorted so two generations compare as strings. A line is
+	// 'nftset=/<domain>/<spec>[,<spec>...] # <comment>' and each spec ends in the
+	// set name, so one domain can feed several sets and one set many domains.
+	let _parse_dnsmasq_sets = function(content) {
+		let seen = {};
+		for (let line in split('' + (content || ''), '\n')) {
+			if (substr(line, 0, 8) != 'nftset=/') continue;
+			let rest = substr(line, 8);
+			let dpos = index(rest, '/');
+			if (dpos < 0) continue;
+			let domain = substr(rest, 0, dpos);
+			let specs = substr(rest, dpos + 1);
+			let cpos = index(specs, ' #');
+			if (cpos >= 0) specs = substr(specs, 0, cpos);
+			for (let spec in split(specs, ',')) {
+				let parts = split(trim(spec), '#');
+				let name = parts[length(parts) - 1];
+				if (!name) continue;
+				if (!seen[name]) seen[name] = {};
+				seen[name][domain] = true;
+			}
+		}
+		let out = {};
+		for (let name in seen)
+			out[name] = join(',', sort(keys(seen[name])));
+		return out;
+	};
+
 	nftset.add_dnsmasq_element = function(iface, target, type_val, uid, comment, param) {
 		let ns = _nftset_names(iface, target, type_val, uid);
 		if (!ns) return false;
@@ -592,13 +626,15 @@ function create_nft(fs_mod, config, sh, output, pkg, platform, network, V, state
 		return _nftset_result(v4_ok, v6_ok);
 	};
 
+	nftset.flush_name = function(name) {
+		return !!name && nft_call('flush', 'set', 'inet', pkg.nft_table, name);
+	};
+
 	nftset.flush = function(iface, target, type_val, uid) {
 		let ns = _nftset_names(iface, target, type_val, uid);
 		if (!ns) return false;
-		let nft_table = pkg.nft_table;
-		let v4_ok = false, v6_ok = false;
-		if (nft_call('flush', 'set', 'inet', nft_table, ns.n4)) v4_ok = true;
-		if (nft_call('flush', 'set', 'inet', nft_table, ns.n6)) v6_ok = true;
+		let v4_ok = nftset.flush_name(ns.n4);
+		let v6_ok = nftset.flush_name(ns.n6);
 		return _nftset_result(v4_ok, v6_ok);
 	};
 
@@ -948,8 +984,12 @@ function create_nft(fs_mod, config, sh, output, pkg, platform, network, V, state
 				let md5_out = sh.exec('md5sum ' + sh.quote(pkg.dnsmasq_file));
 				let m = match(md5_out, /^(\S+)/);
 				resolver_stored_hash = m ? m[1] : '';
+				// Snapshot which domains fed which set before configure()
+				// truncates the file; flush_changed() diffs against this.
+				resolver_prev_domains = _parse_dnsmasq_sets(readfile(pkg.dnsmasq_file));
 			} else {
 				resolver_stored_hash = '';
+				resolver_prev_domains = null;
 			}
 			return true;
 		}
@@ -982,6 +1022,50 @@ function create_nft(fs_mod, config, sh, output, pkg, platform, network, V, state
 			return false;
 		}
 		return false;
+	};
+
+	// Empty the sets whose domain list changed in this generation.
+	//
+	// Set names are keyed on the policy's uid, not on its contents, so editing a
+	// policy's dest_addr reuses the same set. Since #155 stopped deleting live
+	// sets, that set survives the reload with every address the *old* domain
+	// list resolved to still in it, and the policy keeps routing a domain that
+	// is no longer configured anywhere. cleanup('orphan_sets') does not catch
+	// this: the set is still declared by the new ruleset, so it is kept.
+	//
+	// Only sets that existed in the previous generation and whose domain list
+	// actually differs are flushed. Untouched sets keep their addresses, which
+	// is the whole point of #155 -- flushing everything on every reload would
+	// de-route any domain a client still has cached, since nothing re-queries
+	// on its behalf. A set with no previous generation to compare against is
+	// left alone for the same reason.
+	//
+	// This flushes rather than deletes, and runs as a live nft command after
+	// nft_file.apply('main'): the set object never goes away, so dnsmasq's
+	// nftset= target stays valid throughout and no reply lands in a gap. It
+	// must run before resolver.restart(), so that addresses re-resolved after
+	// the restart are not wiped by a later flush.
+	resolver.flush_changed = function() {
+		switch (cfg.resolver_set) {
+		case '':
+		case 'none':
+			return true;
+		case 'dnsmasq.nftset': {
+			if (!env.resolver_set_supported) return true;
+			if (resolver_prev_domains == null) return true;
+			let now = _parse_dnsmasq_sets(readfile(pkg.dnsmasq_file));
+			for (let name in now) {
+				if (!exists(resolver_prev_domains, name)) continue;
+				if (resolver_prev_domains[name] == now[name]) continue;
+				if (nftset.flush_name(name))
+					output.verbose.write("Flushed '" + name + "' - its domain list changed\n");
+			}
+			return true;
+		}
+		case 'unbound.nftset':
+			return true;
+		}
+		return true;
 	};
 
 	resolver.configure = function() {

--- a/files/lib/pbr/pbr.uc
+++ b/files/lib/pbr/pbr.uc
@@ -1952,6 +1952,9 @@ function create_pbr(fs_mod, uci_mod, ubus_mod) {
 			// the new ruleset is live, and skipped when it failed to install,
 			// since the sets still in use are then the previous file's.
 			if (nft_applied) nft.cleanup('orphan_sets');
+			// Before the restart below, so addresses re-resolved after it are
+			// not wiped by a flush that follows.
+			if (nft_applied) nft.resolver.flush_changed();
 
 			if (nft.resolver.compare_hash()) nft.resolver.restart();
 			else nft.resolver.flush_cache();

--- a/tests/03_nft_rules/09_flush_changed_domain_sets
+++ b/tests/03_nft_rules/09_flush_changed_domain_sets
@@ -1,0 +1,95 @@
+Testing that a resolver set is emptied when its policy's domain list changes.
+
+nft set names are keyed on the policy's uid, not on its contents, so editing a
+policy's dest_addr reuses the same set. Since #155 stopped deleting live sets on
+reload, that set survives with every address the *old* domain list resolved to
+still in it, and the policy goes on routing a domain that is no longer configured
+anywhere. cleanup('orphan_sets') does not catch it -- the set is still declared by
+the new ruleset, so it is kept -- and nothing else ever emptied a live set.
+
+Only sets whose domain list actually changed are flushed. Flushing every set on
+every reload would undo #155: a domain a client still has cached is never
+re-queried, so it would silently drop out of policy routing. A set with no
+previous generation to compare against is left alone for the same reason.
+
+-- Testcase --
+import create_pbr from 'pbr';
+
+// The generation that was live before this run. 'pol_changed' was fed by a
+// domain that the config below no longer mentions; 'pol_same' is unchanged.
+global.mocklib.capture('/var/run/pbr.dnsmasq',
+	'nftset=/old.example.com/4#inet#fw4#pbr_wan_4_dst_ip_pol_changed,6#inet#fw4#pbr_wan_6_dst_ip_pol_changed # Changed\n' +
+	'nftset=/stable.example.com/4#inet#fw4#pbr_wan_4_dst_ip_pol_same,6#inet#fw4#pbr_wan_6_dst_ip_pol_same # Same\n');
+
+let pbr = create_pbr();
+pbr.start_service(['on_start']);
+
+let flushed = (name) => global.mocklib.has_command('flush set inet fw4 ' + name + ' ');
+let checks = [];
+
+// Domain list changed: both families of that set must be emptied.
+push(checks, ['changed_v4_flushed', flushed('pbr_wan_4_dst_ip_pol_changed')]);
+push(checks, ['changed_v6_flushed', flushed('pbr_wan_6_dst_ip_pol_changed')]);
+
+// Domain list identical: the set keeps its addresses.
+push(checks, ['unchanged_v4_kept', !flushed('pbr_wan_4_dst_ip_pol_same')]);
+push(checks, ['unchanged_v6_kept', !flushed('pbr_wan_6_dst_ip_pol_same')]);
+
+// No previous generation for this set: nothing to go stale, nothing to flush.
+push(checks, ['new_set_not_flushed', !flushed('pbr_wan_4_dst_ip_pol_new')]);
+
+// The sets are emptied, never deleted -- deleting is what left dnsmasq's
+// nftset= target missing for the length of the rebuild.
+let deletes = global.mocklib.commands('delete set inet fw4 pbr_wan_4_dst_ip_pol_changed');
+push(checks, ['changed_set_not_deleted', length(deletes) == 0]);
+
+// The new generation is what the dnsmasq file ends up describing.
+let dnsmasq = global.mocklib.read_captured('/var/run/pbr.dnsmasq') || '';
+push(checks, ['old_domain_gone',  index(dnsmasq, 'old.example.com') < 0]);
+push(checks, ['new_domain_present', index(dnsmasq, 'new.example.com') >= 0]);
+
+let pass = 0, fail = 0;
+for (let c in checks) {
+	if (c[1]) {
+		pass++;
+	} else {
+		fail++;
+		printf("FAIL: %s\n", c[0]);
+	}
+}
+printf("flush_changed_domain_sets: %d/%d passed\n", pass, pass + fail);
+-- End --
+
+-- File uci/pbr.json --
+{
+	"pbr": [
+		{
+			".name": "config", "enabled": "1", "fw_mask": "00ff0000", "ipv6_enabled": "1",
+			"resolver_set": "dnsmasq.nftset", "strict_enforcement": "1",
+			"uplink_interface": "wan", "uplink_interface6": "wan6",
+			"uplink_ip_rules_priority": "30000", "uplink_mark": "00010000", "verbosity": "2",
+			"lan_device": ["br-lan"], "resolver_instance": ["*"], "debug_performance": "0",
+			"nft_set_auto_merge": "1", "nft_set_flags_interval": "1", "nft_set_flags_timeout": "0",
+			"nft_set_policy": "performance", "ignored_interface": ["vpnserver"]
+		}
+	],
+	"policy": [
+		{
+			".name": "pol_changed", "name": "Changed", "enabled": "1", "interface": "wan",
+			"dest_addr": "new.example.com", "chain": "prerouting"
+		},
+		{
+			".name": "pol_same", "name": "Same", "enabled": "1", "interface": "wan",
+			"dest_addr": "stable.example.com", "chain": "prerouting"
+		},
+		{
+			".name": "pol_new", "name": "New", "enabled": "1", "interface": "wan",
+			"dest_addr": "brand.example.com", "chain": "prerouting"
+		}
+	]
+}
+-- End --
+
+-- Expect stdout --
+flush_changed_domain_sets: 8/8 passed
+-- End --

--- a/tests/03_nft_rules/10_reload_keeps_unchanged_sets
+++ b/tests/03_nft_rules/10_reload_keeps_unchanged_sets
@@ -1,0 +1,127 @@
+Testing that a plain reload and an interface reload never empty a resolver set.
+
+Flushing on a reload that changed nothing would undo #155 twice over: a domain a
+client still has cached is never re-queried, so it would silently drop out of
+policy routing, and pbr would be churning kernel state on every config.change
+trigger. Only a set whose domain list actually differs may be flushed.
+
+'service pbr reload' arrives as 'on_reload', which resolves to the same default
+branch as 'on_start' -- full teardown and rebuild -- so it does run the flush
+logic and has to be proven inert when nothing moved. 'on_interface_reload' takes
+its own branch, which reloads routing only: it never truncates the dnsmasq file,
+never calls nft_file.apply('main'), and so never reaches the flush at all.
+
+Neither path may delete a set either. That is what left dnsmasq's nftset= target
+missing mid-rebuild and produced 'Error: No such file or directory' for every
+reply landing in the gap.
+
+-- Testcase --
+import create_pbr from 'pbr';
+
+// The live generation, byte-identical to what this config regenerates.
+let live = 'nftset=/stable.example.com/4#inet#fw4#pbr_wan_4_dst_ip_pol_stable,6#inet#fw4#pbr_wan_6_dst_ip_pol_stable # Stable\n';
+global.mocklib.capture('/var/run/pbr.dnsmasq', live);
+
+let checks = [];
+let flushes = () => global.mocklib.commands('flush set inet fw4 pbr_');
+let deletes = () => global.mocklib.commands('delete set inet fw4 pbr_');
+
+// ── 'service pbr reload' ────────────────────────────────────────────────
+let pbr = create_pbr();
+pbr.start_service(['on_reload']);
+
+push(checks, ['reload_flushes_nothing', length(flushes()) == 0]);
+push(checks, ['reload_deletes_nothing', length(deletes()) == 0]);
+
+// The set stays declared by the new ruleset, so it is never missing.
+let nft_content = global.mocklib.read_captured('/var/run/pbr.nft') || '';
+push(checks, ['reload_set_still_declared',
+	index(nft_content, 'add set inet fw4 pbr_wan_4_dst_ip_pol_stable ') >= 0]);
+push(checks, ['reload_dnsmasq_unchanged',
+	global.mocklib.read_captured('/var/run/pbr.dnsmasq') == live]);
+
+// ── 'service pbr on_interface_reload wan' ───────────────────────────────
+global.mocklib.clear_commands();
+// Drop the installed ruleset: this branch reloads routing only, so if it were
+// silently downgraded to 'on_start' -- which happens when the service looks
+// stopped or has no published gateways -- nft_file.apply('main') would write
+// the file again and the assertions below would be testing the wrong path.
+global.mocklib.delete_captured('/var/run/pbr.nft');
+
+let pbr2 = create_pbr();
+pbr2.start_service(['on_interface_reload', 'wan']);
+
+push(checks, ['iface_reload_took_its_own_branch',
+	!global.mocklib.has_captured('/var/run/pbr.nft')]);
+push(checks, ['iface_reload_flushes_nothing', length(flushes()) == 0]);
+push(checks, ['iface_reload_deletes_nothing', length(deletes()) == 0]);
+push(checks, ['iface_reload_dnsmasq_untouched',
+	global.mocklib.read_captured('/var/run/pbr.dnsmasq') == live]);
+
+let pass = 0, fail = 0;
+for (let c in checks) {
+	if (c[1]) {
+		pass++;
+	} else {
+		fail++;
+		printf("FAIL: %s\n", c[0]);
+	}
+}
+printf("reload_keeps_unchanged_sets: %d/%d passed\n", pass, pass + fail);
+-- End --
+
+-- File fs/popen~nft_list_table_inet_fw4_2_dev_null.txt --
+table inet fw4 {
+	chain pbr_mark_0x010000 {
+		meta mark set (meta mark & 0xff00ffff) | 0x010000
+		return
+	}
+
+	set pbr_wan_4_dst_ip_pol_stable {
+		type ipv4_addr
+	}
+
+	set pbr_wan_6_dst_ip_pol_stable {
+		type ipv6_addr
+	}
+}
+-- End --
+
+-- File ubus/service~list~name-pbr.json --
+{
+	"pbr": {
+		"data": {
+			"gateways": [
+				{ "name": "wan", "gateway_ipv4": "192.168.1.1" },
+				{ "name": "wan6", "gateway_ipv6": "2001:db8::ffff" }
+			]
+		}
+	}
+}
+-- End --
+
+-- File uci/pbr.json --
+{
+	"pbr": [
+		{
+			".name": "config", "enabled": "1", "fw_mask": "00ff0000", "ipv6_enabled": "1",
+			"resolver_set": "dnsmasq.nftset", "strict_enforcement": "1",
+			"uplink_interface": "wan", "uplink_interface6": "wan6",
+			"uplink_ip_rules_priority": "30000", "uplink_mark": "00010000", "verbosity": "2",
+			"lan_device": ["br-lan"], "resolver_instance": ["*"], "debug_performance": "0",
+			"nft_set_auto_merge": "1", "nft_set_flags_interval": "1", "nft_set_flags_timeout": "0",
+			"nft_set_policy": "performance", "ignored_interface": ["vpnserver"]
+		}
+	],
+	"policy": [
+		{
+			".name": "pol_stable", "name": "Stable", "enabled": "1", "interface": "wan",
+			"dest_addr": "stable.example.com", "chain": "prerouting"
+		}
+	]
+}
+-- End --
+
+-- Expect stdout --
+reload_keeps_unchanged_sets: 8/8 passed
+-- End --


### PR DESCRIPTION
## The bug

`nft` set names are keyed on the policy's uid, not on its contents, so editing a policy's `dest_addr` reuses the same set. Since #155 stopped deleting live sets on reload, that set survives the rebuild still holding every address the **old** domain list resolved to — and the policy goes on routing a domain that is no longer configured anywhere. Not in `/etc/config/pbr`, not in `/var/run/pbr.dnsmasq`, not in the ruleset. Only in the set the rule matches on, and nothing logs it.

`cleanup('orphan_sets')` does not catch this: the set is still declared by the new ruleset, so it is kept. That is why *disabling* a policy did clear its set — a disabled policy declares nothing, so the set is reaped as an orphan — while *editing* one did not. The two operations appeared to behave inconsistently for no visible reason, which is how this was found.

`nft_set_timeout` / `nft_set_gc_interval` are unset by default, so the entries are permanent until reboot.

Nothing in the package ever emptied a live set. `nftset.flush()` existed for precisely this and had no callers.

## The fix

`resolver.store_hash()` now also snapshots which domains fed which set, parsed out of the dnsmasq file before `configure()` truncates it — it already read that file for the md5, so the previous generation was available and simply not kept. After `nft_file.apply('main')`, the new `resolver.flush_changed()` re-parses the regenerated file and empties only the sets whose domain list actually differs.

Deliberately narrow, on both sides:

- **Flush, never delete.** The set object never goes away, so dnsmasq's `nftset=` target stays resolvable and no reply lands in a gap. That gap is what #155 closed and it is not being reopened. Flushing a set referenced by live rules is always permitted; only deleting one is refused with `EBUSY`.
- **A live `nft` command after `apply('main')`, not a line in `30-pbr.nft`.** `fw4` re-executes that file on every reload, including reloads `pbr` did not trigger, so a `flush set` baked into it would empty the sets continuously.
- **Only sets present in both generations with a differing domain list.** Flushing everything on every reload would undo #155 from the other side: a domain a client still holds cached is never re-queried, so it would silently drop out of policy routing. A set with no previous generation to compare against is left alone for the same reason.
- **Before `resolver.restart()`**, so addresses re-resolved after the restart are not wiped by a flush that follows.

The comparison is a sorted, de-duplicated `domain,domain` string per set name, so a rewrite that merges or orders the file differently without changing which domains feed a set still compares equal.

`nftset.flush()` now delegates to a new `nftset.flush_name()`, which flushes by set name, rather than repeating the command.

## Reload paths

`service pbr reload` arrives as `on_reload` and resolves to the same `default:` branch as `on_start`, so it does run this — and is proven inert when nothing changed.

`on_interface_reload` takes its own branch, which reloads routing only: it never calls `configure()` or `nft_file.apply('main')`, so it cannot reach the flush at all.

## Tests

`tests/03_nft_rules/09_flush_changed_domain_sets` seeds a previous generation and covers three policies: a changed domain list flushes both families, an identical one is left alone, a set with no previous generation is untouched. It also asserts the set is flushed rather than deleted. Verified as a real guard — with the `flush_changed()` call removed it fails on the two changed-set assertions instead of passing vacuously.

`tests/03_nft_rules/10_reload_keeps_unchanged_sets` pins the two paths that must never empty anything.

Its interface-reload half needed a new fixture. `get_mark_nft_chains()` runs `nft list table inet fw4 2>/dev/null`, but the only popen fixture in the tree was for `2>&1`, so `is_service_running_nft()` was always false in tests and any `on_interface_reload` case was silently downgraded to `on_start` — testing the wrong branch while still passing. The test now also asserts `nft_file.apply('main')` never ran on that path, so it cannot go vacuous again.

54/54 passing.

## Verification

Tested on the router.

🤖 Generated with [Claude Code](https://claude.com/claude-code)