### PR TITLE
pbr-1.2.3: apply address negations on the policy's own rules

### DIFF
--- a/files/lib/pbr/nft.uc
+++ b/files/lib/pbr/nft.uc
@@ -1168,6 +1168,10 @@ function create_nft(fs_mod, config, sh, output, pkg, platform, network, V, state
 		// different list of domains than the policy's positive group, and both
 		// are keyed on the same uid. Fold the suffix into the uid so the set
 		// that gets created and populated is the very one the rule references.
+		// A falsy uid is passed through untouched: only the resolver branch
+		// below consumes this, and the one caller that passes no uid -- the DNS
+		// path, with use_resolver false -- never reaches it, so there is no set
+		// name to suffix.
 		let set_uid = (uid && nftset_suffix) ? '' + uid + nftset_suffix : uid;
 		let first_val = V.str_first_word(value);
 		let param4 = '', param6 = '';

--- a/files/lib/pbr/nft.uc
+++ b/files/lib/pbr/nft.uc
@@ -1172,7 +1172,8 @@ function create_nft(fs_mod, config, sh, output, pkg, platform, network, V, state
 		// below consumes this, and the one caller that passes no uid -- the DNS
 		// path, with use_resolver false -- never reaches it, so there is no set
 		// name to suffix.
-		let set_uid = (uid && nftset_suffix) ? '' + uid + nftset_suffix : uid;
+		let set_uid = uid;
+		if (uid && nftset_suffix) set_uid = '' + uid + nftset_suffix;
 		let first_val = V.str_first_word(value);
 		let param4 = '', param6 = '';
 		let empty4 = false, empty6 = false;

--- a/files/lib/pbr/nft.uc
+++ b/files/lib/pbr/nft.uc
@@ -1164,6 +1164,11 @@ function create_nft(fs_mod, config, sh, output, pkg, platform, network, V, state
 			value = replace(value, /!/g, '');
 			nftset_suffix = '_neg';
 		}
+		// The negated group of a policy needs its own resolver set: it holds a
+		// different list of domains than the policy's positive group, and both
+		// are keyed on the same uid. Fold the suffix into the uid so the set
+		// that gets created and populated is the very one the rule references.
+		let set_uid = (uid && nftset_suffix) ? '' + uid + nftset_suffix : uid;
 		let first_val = V.str_first_word(value);
 		let param4 = '', param6 = '';
 		let empty4 = false, empty6 = false;
@@ -1180,13 +1185,12 @@ function create_nft(fs_mod, config, sh, output, pkg, platform, network, V, state
 			param6 = param4;
 		} else if (V.is_domain(first_val)) {
 			if (use_resolver && iface &&
-				resolver.create_set(iface, target, 'ip', uid, name) &&
-				resolver.add_element(iface, target, 'ip', uid, name, value)) {
-				let nft_pfx = pkg.nft_prefix;
+				resolver.create_set(iface, target, 'ip', set_uid, name) &&
+				resolver.add_element(iface, target, 'ip', set_uid, name, value)) {
 				param4 = pkg.nft_ipv4_flag + ' ' + addr_dir + ' ' + negation +
-					'@' + nft_pfx + '_' + iface + '_4_' + target + '_ip_' + uid + nftset_suffix;
+					'@' + get_set_name(iface, '4', target, 'ip', set_uid);
 				param6 = pkg.nft_ipv6_flag + ' ' + addr_dir + ' ' + negation +
-					'@' + nft_pfx + '_' + iface + '_6_' + target + '_ip_' + uid + nftset_suffix;
+					'@' + get_set_name(iface, '6', target, 'ip', set_uid);
 			} else {
 				let is4 = '', is6 = '';
 				for (let d in split(value, /\s+/)) {

--- a/files/lib/pbr/pbr.uc
+++ b/files/lib/pbr/pbr.uc
@@ -278,9 +278,36 @@ function create_pbr(fs_mod, uci_mod, ubus_mod) {
 		return true;
 	}
 	
+	// ── Address Exclusions ──────────────────────────────────────────────
+	
+	// nft has no OR between the match expressions of a rule, so every positive
+	// address type a policy names needs a rule of its own -- that is what makes
+	// src_addr/dest_addr a union of sources. Negated entries are the opposite:
+	// they are AND terms and belong ON those rules. Given a rule of its own a
+	// '!10.0.0.22' reads as "everything except 10.0.0.22", a catch-all that
+	// swallows exactly the traffic the policy was meant to leave alone.
+	//
+	// Resolve a policy's negated groups once, into the fragments appended to
+	// every rule it emits. classify_addr() keeps the families apart, so an IPv4
+	// exclusion only ever reaches the IPv4 rule and vice versa. 'matched' feeds
+	// the unknown-entry check in the callers.
+	function collect_negations(list, addr, direction, iface, uid, name, use_resolver) {
+		let n4 = '', n6 = '', matched = '';
+		if (!addr) return { n4, n6, matched };
+		for (let fg in split(list, /\s+/)) {
+			let fv = V.filter_options(fg, addr);
+			if (!fv) continue;
+			matched += (matched ? ' ' : '') + fv;
+			let r = nft.classify_addr(fv, direction, iface, uid, name, use_resolver);
+			if (r.param4 && !r.empty4) n4 += (n4 ? ' ' : '') + r.param4;
+			if (r.param6 && !r.empty6) n6 += (n6 ? ' ' : '') + r.param6;
+		}
+		return { n4, n6, matched };
+	}
+	
 	// ── DNS Policy Routing ──────────────────────────────────────────────
 	
-	function dns_policy_routing(name, src_addr, dest_dns, uid, dest_dns_port, dest_dns_ipv4, dest_dns_ipv6) {
+	function dns_policy_routing(name, src_addr, dest_dns, uid, dest_dns_port, dest_dns_ipv4, dest_dns_ipv6, src_neg) {
 		let nft_insert = 'add';
 		let protos = ['tcp', 'udp'];
 		let chain = 'dstnat';
@@ -293,22 +320,28 @@ function create_pbr(fs_mod, uci_mod, ubus_mod) {
 			return 1;
 		}
 	
-		if (!cfg.ipv6_enabled && V.is_ipv6(V.str_first_word(src_addr))) {
+		// A rule built from exclusions alone has no positive source to take its
+		// family from, so fall back to the negated entries for the guards below
+		// and let the exclusions themselves decide which families to emit.
+		let raw_src = src_addr || (src_neg ? src_neg.matched : '') || '';
+		let clean_src = raw_src ? replace('' + raw_src, /!/g, '') : '';
+		let first_value = V.str_first_word(clean_src);
+		let src_is_v4 = src_addr ? !V.is_ipv6(first_value) : !!(src_neg && src_neg.n4);
+		let src_is_v6 = src_addr ? !V.is_ipv4(first_value) : !!(src_neg && src_neg.n6);
+	
+		if (!cfg.ipv6_enabled && V.is_ipv6(first_value)) {
 			process_dns_policy_error = true;
 			push(state.errors, { code: 'errorPolicyProcessNoIpv6', info: name });
 			return 1;
 		}
 	
-		if ((V.is_ipv4(V.str_first_word(src_addr)) && !dest_dns_ipv4) ||
-			(V.is_ipv6(V.str_first_word(src_addr)) && !dest_dns_ipv6)) {
+		if ((V.is_ipv4(first_value) && !dest_dns_ipv4) ||
+			(V.is_ipv6(first_value) && !dest_dns_ipv6)) {
 			process_dns_policy_error = true;
 			push(state.errors, { code: 'errorPolicyProcessMismatchFamily',
-				info: name + ": '" + src_addr + "' '" + dest_dns + "':'" + dest_dns_port + "'" });
+				info: name + ": '" + raw_src + "' '" + dest_dns + "':'" + dest_dns_port + "'" });
 			return 1;
 		}
-	
-		let clean_src = src_addr ? ((substr(src_addr, 0, 1) == '!') ? replace(src_addr, /!/g, '') : src_addr) : '';
-		let first_value = V.str_first_word(clean_src);
 	
 		for (let proto_i in protos) {
 			let param4 = '', param6 = '';
@@ -328,6 +361,18 @@ function create_pbr(fs_mod, uci_mod, ubus_mod) {
 				param6 = r.param6;
 				inline_set_ipv4_empty = r.empty4;
 				inline_set_ipv6_empty = r.empty6;
+			} else if (src_neg && (src_neg.n4 || src_neg.n6)) {
+				// Exclusions with no positive source: suppress the family that
+				// carries none of them, or its rule would match every packet.
+				inline_set_ipv4_empty = !src_neg.n4;
+				inline_set_ipv6_empty = !src_neg.n6;
+			}
+	
+			// DNS rules already pin their family with 'meta nfproto', so the
+			// exclusions can just be appended to the rule they belong to.
+			if (src_neg) {
+				if (src_neg.n4) param4 += (param4 ? ' ' : '') + src_neg.n4;
+				if (src_neg.n6) param6 += (param6 ? ' ' : '') + src_neg.n6;
 			}
 	
 			let rule_params = cfg._nft_rule_params ? ' ' + cfg._nft_rule_params : '';
@@ -340,12 +385,12 @@ function create_pbr(fs_mod, uci_mod, ubus_mod) {
 	
 			let ipv4_error = false, ipv6_error = false;
 			if (pbr_nft_prev_param4 != param4 && first_value &&
-				!V.is_ipv6(first_value) && !inline_set_ipv4_empty && dest_dns_ipv4) {
+				src_is_v4 && !inline_set_ipv4_empty && dest_dns_ipv4) {
 				if (!nft.nft4(param4)) ipv4_error = true;
 				pbr_nft_prev_param4 = param4;
 			}
 			if (pbr_nft_prev_param6 != param6 && param4 != param6 &&
-				first_value && !V.is_ipv4(first_value) && !inline_set_ipv6_empty && dest_dns_ipv6) {
+				first_value && src_is_v6 && !inline_set_ipv6_empty && dest_dns_ipv6) {
 				if (!nft.nft6(param6)) ipv6_error = true;
 				pbr_nft_prev_param6 = param6;
 			}
@@ -365,7 +410,7 @@ function create_pbr(fs_mod, uci_mod, ubus_mod) {
 	
 	// ── Policy Routing ──────────────────────────────────────────────────
 	
-	function policy_routing(name, iface, src_addr, src_port, dest_addr, dest_port, proto, chain, uid) {
+	function policy_routing(name, iface, src_addr, src_port, dest_addr, dest_port, proto, chain, uid, src_neg, dest_neg) {
 		let nft_insert = 'add';
 		let nft_table = pkg.nft_table;
 		let nft_prefix = pkg.nft_prefix;
@@ -374,8 +419,13 @@ function create_pbr(fs_mod, uci_mod, ubus_mod) {
 		proto = lc(proto || '');
 		chain = lc(chain || '') || 'prerouting';
 	
+		// A rule built from exclusions alone still has a family; read it off the
+		// negated entries when there is no positive address to read it from.
+		let raw_src = src_addr || (src_neg ? src_neg.matched : '') || '';
+		let raw_dest = dest_addr || (dest_neg ? dest_neg.matched : '') || '';
 		if (!cfg.ipv6_enabled &&
-			(V.is_ipv6(V.str_first_word(src_addr)) || V.is_ipv6(V.str_first_word(dest_addr)))) {
+			(V.is_ipv6(V.str_first_word(replace('' + raw_src, /!/g, ''))) ||
+			 V.is_ipv6(V.str_first_word(replace('' + raw_dest, /!/g, ''))))) {
 			process_policy_error = true;
 			push(state.errors, { code: 'errorPolicyProcessNoIpv6', info: name });
 			return 1;
@@ -448,6 +498,11 @@ function create_pbr(fs_mod, uci_mod, ubus_mod) {
 				param6 = r.param6;
 				src_inline_set_ipv4_empty = r.empty4;
 				src_inline_set_ipv6_empty = r.empty6;
+			} else if (src_neg && (src_neg.n4 || src_neg.n6)) {
+				// Exclusions with no positive source: suppress the family that
+				// carries none of them, or its rule would match every packet.
+				src_inline_set_ipv4_empty = !src_neg.n4;
+				src_inline_set_ipv6_empty = !src_neg.n6;
 			}
 	
 			if (dest_addr) {
@@ -456,7 +511,31 @@ function create_pbr(fs_mod, uci_mod, ubus_mod) {
 				param6 += (param6 ? ' ' : '') + r.param6;
 				dest_inline_set_ipv4_empty = r.empty4;
 				dest_inline_set_ipv6_empty = r.empty6;
+			} else if (dest_neg && (dest_neg.n4 || dest_neg.n6)) {
+				dest_inline_set_ipv4_empty = !dest_neg.n4;
+				dest_inline_set_ipv6_empty = !dest_neg.n6;
 			}
+	
+			// An interface or MAC match (and an absent one) reads the same for
+			// both families, so only one rule is emitted for it. A family-
+			// specific exclusion breaks that: the IPv6 copy would carry no
+			// exclusion and re-admit the very IPv4 packets the IPv4 copy just
+			// filtered out. Pin each copy to its family before appending. An
+			// empty positive match needs no guard: the family that carries no
+			// exclusion is already suppressed above.
+			let family_agnostic = (param4 == param6 && param4 != '');
+			let neg4 = src_neg ? src_neg.n4 : '';
+			let neg6 = src_neg ? src_neg.n6 : '';
+			if (dest_neg) {
+				if (dest_neg.n4) neg4 += (neg4 ? ' ' : '') + dest_neg.n4;
+				if (dest_neg.n6) neg6 += (neg6 ? ' ' : '') + dest_neg.n6;
+			}
+			if (family_agnostic && neg4 != neg6) {
+				param4 = 'meta nfproto ipv4' + (param4 ? ' ' + param4 : '');
+				param6 = 'meta nfproto ipv6' + (param6 ? ' ' + param6 : '');
+			}
+			if (neg4) param4 += (param4 ? ' ' : '') + neg4;
+			if (neg6) param6 += (param6 ? ' ' : '') + neg6;
 	
 			if (src_port) {
 				let negation = '', value = src_port;
@@ -592,15 +671,22 @@ function create_pbr(fs_mod, uci_mod, ubus_mod) {
 			output.fail(); return 1;
 		}
 	
-		let filter_list = 'phys_dev phys_dev_negative mac_address mac_address_negative domain domain_negative ipv4 ipv4_negative ipv6 ipv6_negative';
+		let filter_list = 'phys_dev mac_address domain ipv4 ipv6';
+		let neg_list = 'phys_dev_negative mac_address_negative domain_negative ipv4_negative ipv6_negative';
+		let src_neg = collect_negations(neg_list, src_addr, 'src', null, null, name, false);
+		let has_positive = false;
 		for (let fg in split(filter_list, /\s+/)) {
 			let filtered = V.filter_options(fg, src_addr);
-			if (src_addr && filtered) {
-				if (V.str_contains(fg, 'ipv4') && !dest_dns_ipv4) continue;
-				if (V.str_contains(fg, 'ipv6') && !dest_dns_ipv6) continue;
-				dns_policy_routing(name, filtered, dest_dns, uid, dest_dns_port, dest_dns_ipv4, dest_dns_ipv6);
-			}
+			if (!filtered) continue;
+			has_positive = true;
+			if (V.str_contains(fg, 'ipv4') && !dest_dns_ipv4) continue;
+			if (V.str_contains(fg, 'ipv6') && !dest_dns_ipv6) continue;
+			dns_policy_routing(name, filtered, dest_dns, uid, dest_dns_port, dest_dns_ipv4, dest_dns_ipv6, src_neg);
 		}
+		// Nothing but exclusions in src_addr: emit the single rule they describe,
+		// 'every source but these'.
+		if (!has_positive && (src_neg.n4 || src_neg.n6))
+			dns_policy_routing(name, '', dest_dns, uid, dest_dns_port, dest_dns_ipv4, dest_dns_ipv6, src_neg);
 	
 		if (process_dns_policy_error) output.fail();
 		else output.ok();
@@ -686,25 +772,46 @@ function create_pbr(fs_mod, uci_mod, ubus_mod) {
 		}
 		dest_addr = join(' ', j_parts);
 	
-		let filter_list_src = 'phys_dev phys_dev_negative mac_address mac_address_negative domain domain_negative ipv4 ipv4_negative ipv6 ipv6_negative';
-		let filter_list_dest = 'domain domain_negative ipv4 ipv4_negative ipv6 ipv6_negative';
+		let filter_list_src = 'phys_dev mac_address domain ipv4 ipv6';
+		let filter_list_dest = 'domain ipv4 ipv6';
+		let neg_list_src = 'phys_dev_negative mac_address_negative domain_negative ipv4_negative ipv6_negative';
+		let neg_list_dest = 'domain_negative ipv4_negative ipv6_negative';
 		let processed_src = '', processed_dest = '';
 	
-		if (!src_addr) filter_list_src = 'none';
-		for (let fg_src in split(filter_list_src, /\s+/)) {
-			let fv_src = V.filter_options(fg_src, src_addr);
-			if (!src_addr || (src_addr && fv_src)) {
-				let fl_dest = dest_addr ? filter_list_dest : 'none';
-				for (let fg_dest in split(fl_dest, /\s+/)) {
-					let fv_dest = V.filter_options(fg_dest, dest_addr);
-					if (!dest_addr || (dest_addr && fv_dest)) {
-						if (V.str_contains(fg_src, 'ipv4') && V.str_contains(fg_dest, 'ipv6')) continue;
-						if (V.str_contains(fg_src, 'ipv6') && V.str_contains(fg_dest, 'ipv4')) continue;
-						policy_routing(name, interface_name, fv_src, src_port, fv_dest, dest_port, proto, chain, uid);
-						processed_src += (processed_src ? ' ' : '') + (fv_src || '');
-						processed_dest += (processed_dest ? ' ' : '') + (fv_dest || '');
-					}
-				}
+		// One rule per positive group -- they are the policy's union of sources.
+		let src_groups = [], dest_groups = [];
+		for (let fg in split(filter_list_src, /\s+/)) {
+			let fv = src_addr ? V.filter_options(fg, src_addr) : '';
+			if (!fv) continue;
+			push(src_groups, { fg, fv });
+			processed_src += (processed_src ? ' ' : '') + fv;
+		}
+		for (let fg in split(filter_list_dest, /\s+/)) {
+			let fv = dest_addr ? V.filter_options(fg, dest_addr) : '';
+			if (!fv) continue;
+			push(dest_groups, { fg, fv });
+			processed_dest += (processed_dest ? ' ' : '') + fv;
+		}
+	
+		// The exclusions ride along on each of those rules instead of getting
+		// rules of their own.
+		let src_neg = collect_negations(neg_list_src, src_addr, 'src', interface_name, uid, name, true);
+		let dest_neg = collect_negations(neg_list_dest, dest_addr, 'dst', interface_name, uid, name, true);
+		if (src_neg.matched) processed_src += (processed_src ? ' ' : '') + src_neg.matched;
+		if (dest_neg.matched) processed_dest += (processed_dest ? ' ' : '') + dest_neg.matched;
+	
+		// No positive entries of a given side (none configured, or nothing but
+		// exclusions) still yields one rule for that side, carrying whatever
+		// exclusions it has.
+		if (!length(src_groups)) push(src_groups, { fg: 'none', fv: '' });
+		if (!length(dest_groups)) push(dest_groups, { fg: 'none', fv: '' });
+	
+		for (let s in src_groups) {
+			for (let d in dest_groups) {
+				if (V.str_contains(s.fg, 'ipv4') && V.str_contains(d.fg, 'ipv6')) continue;
+				if (V.str_contains(s.fg, 'ipv6') && V.str_contains(d.fg, 'ipv4')) continue;
+				policy_routing(name, interface_name, s.fv, src_port, d.fv, dest_port,
+					proto, chain, uid, src_neg, dest_neg);
 			}
 		}
 	

--- a/files/lib/pbr/pbr.uc
+++ b/files/lib/pbr/pbr.uc
@@ -291,6 +291,13 @@ function create_pbr(fs_mod, uci_mod, ubus_mod) {
 	// every rule it emits. classify_addr() keeps the families apart, so an IPv4
 	// exclusion only ever reaches the IPv4 rule and vice versa. 'matched' feeds
 	// the unknown-entry check in the callers.
+	// First word of an address list with the negation markers stripped, used to
+	// read a rule's address family. is_ipv4()/is_ipv6() do not accept a leading
+	// '!', so the markers have to come off before the family is tested.
+	function bare_first_word(raw) {
+		return V.str_first_word(replace('' + (raw || ''), /!/g, ''));
+	}
+
 	function collect_negations(list, addr, direction, iface, uid, name, use_resolver) {
 		let n4 = '', n6 = '', matched = '';
 		if (!addr) return { n4, n6, matched };
@@ -324,8 +331,7 @@ function create_pbr(fs_mod, uci_mod, ubus_mod) {
 		// family from, so fall back to the negated entries for the guards below
 		// and let the exclusions themselves decide which families to emit.
 		let raw_src = src_addr || (src_neg ? src_neg.matched : '') || '';
-		let clean_src = raw_src ? replace('' + raw_src, /!/g, '') : '';
-		let first_value = V.str_first_word(clean_src);
+		let first_value = bare_first_word(raw_src);
 		let src_is_v4 = src_addr ? !V.is_ipv6(first_value) : !!(src_neg && src_neg.n4);
 		let src_is_v6 = src_addr ? !V.is_ipv4(first_value) : !!(src_neg && src_neg.n6);
 	
@@ -424,8 +430,8 @@ function create_pbr(fs_mod, uci_mod, ubus_mod) {
 		let raw_src = src_addr || (src_neg ? src_neg.matched : '') || '';
 		let raw_dest = dest_addr || (dest_neg ? dest_neg.matched : '') || '';
 		if (!cfg.ipv6_enabled &&
-			(V.is_ipv6(V.str_first_word(replace('' + raw_src, /!/g, ''))) ||
-			 V.is_ipv6(V.str_first_word(replace('' + raw_dest, /!/g, ''))))) {
+			(V.is_ipv6(bare_first_word(raw_src)) ||
+			 V.is_ipv6(bare_first_word(raw_dest)))) {
 			process_policy_error = true;
 			push(state.errors, { code: 'errorPolicyProcessNoIpv6', info: name });
 			return 1;

--- a/files/lib/pbr/pbr.uc
+++ b/files/lib/pbr/pbr.uc
@@ -806,11 +806,13 @@ function create_pbr(fs_mod, uci_mod, ubus_mod) {
 		if (!length(src_groups)) push(src_groups, { fg: 'none', fv: '' });
 		if (!length(dest_groups)) push(dest_groups, { fg: 'none', fv: '' });
 	
-		for (let s in src_groups) {
-			for (let d in dest_groups) {
-				if (V.str_contains(s.fg, 'ipv4') && V.str_contains(d.fg, 'ipv6')) continue;
-				if (V.str_contains(s.fg, 'ipv6') && V.str_contains(d.fg, 'ipv4')) continue;
-				policy_routing(name, interface_name, s.fv, src_port, d.fv, dest_port,
+		// ucode's for-in yields an array's values, not its indices, so each of
+		// these is the { fg, fv } pushed above.
+		for (let src_group in src_groups) {
+			for (let dest_group in dest_groups) {
+				if (V.str_contains(src_group.fg, 'ipv4') && V.str_contains(dest_group.fg, 'ipv6')) continue;
+				if (V.str_contains(src_group.fg, 'ipv6') && V.str_contains(dest_group.fg, 'ipv4')) continue;
+				policy_routing(name, interface_name, src_group.fv, src_port, dest_group.fv, dest_port,
 					proto, chain, uid, src_neg, dest_neg);
 			}
 		}

--- a/files/lib/pbr/pbr.uc
+++ b/files/lib/pbr/pbr.uc
@@ -4,6 +4,10 @@
 //
 // Entry point: module wiring, service lifecycle, policy processing,
 // interface routing, netifd integration, status/rpcd.
+//
+// Two ucode divergences from JavaScript that bite here: for-in over an array
+// yields its values, not its indices (there is no for-of), and function
+// declarations are not hoisted, so a helper must appear before its callers.
 
 // ── Constants & Sub-module Factories ────────────────────────────────
 

--- a/tests/03_nft_rules/11_negation_on_same_rule
+++ b/tests/03_nft_rules/11_negation_on_same_rule
@@ -30,6 +30,7 @@ if (nft_content) {
 		index(l, '"' + comment + '"') >= 0);
 	let has = (rules, needle) => length(filter(rules, l => index(l, needle) >= 0));
 
+	// ── policy_mixed: three positive types, a MAC exclusion and an IPv4 one ──
 	let mixed = rules_for('Mixed');
 
 	// One rule per positive group, with the family-agnostic ones (@br-lan and
@@ -67,22 +68,24 @@ if (nft_content) {
 	push(checks, ['mixed_ipv4_group_not_pinned',
 		length(v4_group) == 1 && index(v4_group[0], 'meta nfproto') < 0]);
 
-	// Exclusions with no positive entry still describe one rule -- "every
-	// source but this one" -- and only for the family that has an exclusion.
+	// ── policy_negonly: src_addr is a single exclusion and nothing else ──
+	// It still describes one rule -- "every source but this one" -- and only
+	// for the family that has an exclusion.
 	let negonly = rules_for('NegOnly');
 	push(checks, ['negonly_single_rule', length(negonly) == 1]);
 	push(checks, ['negonly_carries_exclusion', has(negonly, 'ip saddr != { 10.0.0.99 }') == 1]);
 	push(checks, ['negonly_not_pinned', index(negonly[0], 'meta nfproto') < 0]);
 
-	// dest_addr exclusions ride along the same way.
+	// ── policy_dest: the exclusion is on dest_addr, not src_addr ──
 	let destneg = rules_for('DestNeg');
 	push(checks, ['destneg_single_rule', length(destneg) == 1]);
 	push(checks, ['destneg_positive_and_exclusion',
 		index(destneg[0], 'ip daddr { 10.10.0.0/16 }') >= 0 &&
 		index(destneg[0], 'ip daddr != { 10.10.5.5 }') >= 0]);
 
-	// A negated domain gets its own resolver set, and the set the rule points
-	// at has to be the one that actually gets created and populated.
+	// ── policy_domain: a negated domain name, so a resolver set is involved ──
+	// It gets a set of its own, and the set the rule points at has to be the
+	// one that actually gets created and populated.
 	let domneg = rules_for('DomainNeg');
 	push(checks, ['domainneg_single_rule', length(domneg) == 1]);
 	push(checks, ['domainneg_refs_neg_set',

--- a/tests/03_nft_rules/11_negation_on_same_rule
+++ b/tests/03_nft_rules/11_negation_on_same_rule
@@ -1,0 +1,193 @@
+Testing that negated src_addr/dest_addr entries land on the same rule as the
+policy's positive matches instead of getting rules of their own.
+
+nft has no OR between the match expressions of a rule, so a policy's positive
+address types need one rule each -- that is what makes src_addr/dest_addr a
+union of sources. Negated entries are AND terms and belong ON those rules. Given
+a rule of its own, '!10.0.0.22' compiles to 'ip saddr != 10.0.0.22 goto ...',
+which matches every packet that is not from that one host: a catch-all that
+routes the whole network and swallows the traffic the policy meant to skip.
+
+An interface or MAC match reads the same for both families, so it is normally
+emitted once. Adding a family-specific exclusion to it splits it in two, and the
+copies then have to be pinned with 'meta nfproto' -- otherwise the IPv6 copy,
+carrying no IPv4 exclusion, would re-admit the very packets the IPv4 copy just
+filtered out.
+
+-- Testcase --
+import create_pbr from 'pbr';
+let pbr = create_pbr();
+
+pbr.start_service(['on_start']);
+
+let nft_content = global.mocklib.read_captured('/var/run/pbr.nft');
+let dnsmasq = global.mocklib.read_captured('/var/run/pbr.dnsmasq') || '';
+let checks = [];
+
+if (nft_content) {
+	let lines = split(nft_content, '\n');
+	let rules_for = (comment) => filter(lines, l => index(l, ' rule ') >= 0 &&
+		index(l, '"' + comment + '"') >= 0);
+	let has = (rules, needle) => length(filter(rules, l => index(l, needle) >= 0));
+
+	let mixed = rules_for('Mixed');
+
+	// One rule per positive group, with the family-agnostic ones (@br-lan and
+	// the MAC) split per family because an IPv4 exclusion applies to only one.
+	push(checks, ['mixed_rule_count', length(mixed) == 5]);
+
+	// Every rule the policy emits carries a positive match. A rule holding
+	// nothing but exclusions would be the catch-all this test exists to stop.
+	let positives = filter(mixed, l => index(l, 'iifname { br-lan }') >= 0 ||
+		index(l, 'ether saddr { 98:B8:BC:8B:3F:9E }') >= 0 ||
+		index(l, 'ip saddr { 192.168.9.0/24, 10.0.0.0/24 }') >= 0);
+	push(checks, ['mixed_every_rule_has_a_positive', length(positives) == length(mixed)]);
+
+	// The MAC exclusion is family-agnostic, so it rides on all five.
+	push(checks, ['mixed_mac_exclusion_on_every_rule',
+		has(mixed, 'ether saddr != { 11:22:33:44:55:66 }') == 5]);
+
+	// The IPv4 exclusion only belongs on the rules that can carry it: the two
+	// IPv4 copies and the IPv4-only positive group.
+	push(checks, ['mixed_ipv4_exclusion_count', has(mixed, 'ip saddr != { 10.0.0.22 }') == 3]);
+	let v6 = filter(mixed, l => index(l, 'meta nfproto ipv6') >= 0);
+	push(checks, ['mixed_v6_copies', length(v6) == 2]);
+	push(checks, ['mixed_v6_has_no_ipv4_exclusion', has(v6, 'ip saddr != ') == 0]);
+
+	// The split copies must be pinned to a family, or the IPv6 copy would match
+	// the IPv4 packets the IPv4 copy excluded.
+	let agnostic = filter(mixed, l => index(l, 'iifname { br-lan }') >= 0 ||
+		index(l, 'ether saddr { 98:B8:BC:8B:3F:9E }') >= 0);
+	push(checks, ['mixed_agnostic_copies_pinned',
+		length(filter(agnostic, l => index(l, 'meta nfproto ') >= 0)) == 4]);
+
+	// A purely IPv4 positive group already implies its family through
+	// 'ip saddr', so it must not pick up a redundant guard.
+	let v4_group = filter(mixed, l => index(l, 'ip saddr { 192.168.9.0/24') >= 0);
+	push(checks, ['mixed_ipv4_group_not_pinned',
+		length(v4_group) == 1 && index(v4_group[0], 'meta nfproto') < 0]);
+
+	// Exclusions with no positive entry still describe one rule -- "every
+	// source but this one" -- and only for the family that has an exclusion.
+	let negonly = rules_for('NegOnly');
+	push(checks, ['negonly_single_rule', length(negonly) == 1]);
+	push(checks, ['negonly_carries_exclusion', has(negonly, 'ip saddr != { 10.0.0.99 }') == 1]);
+	push(checks, ['negonly_not_pinned', index(negonly[0], 'meta nfproto') < 0]);
+
+	// dest_addr exclusions ride along the same way.
+	let destneg = rules_for('DestNeg');
+	push(checks, ['destneg_single_rule', length(destneg) == 1]);
+	push(checks, ['destneg_positive_and_exclusion',
+		index(destneg[0], 'ip daddr { 10.10.0.0/16 }') >= 0 &&
+		index(destneg[0], 'ip daddr != { 10.10.5.5 }') >= 0]);
+
+	// A negated domain gets its own resolver set, and the set the rule points
+	// at has to be the one that actually gets created and populated.
+	let domneg = rules_for('DomainNeg');
+	push(checks, ['domainneg_single_rule', length(domneg) == 1]);
+	push(checks, ['domainneg_refs_neg_set',
+		index(domneg[0], 'ip daddr != @pbr_wan_4_dst_ip_policy_domain_neg') >= 0]);
+	push(checks, ['domainneg_neg_set_created',
+		index(nft_content, 'add set inet fw4 pbr_wan_4_dst_ip_policy_domain_neg ') >= 0]);
+	push(checks, ['domainneg_neg_set_populated',
+		index(dnsmasq, 'nftset=/blocked.example.com/4#inet#fw4#pbr_wan_4_dst_ip_policy_domain_neg') >= 0]);
+	push(checks, ['domainneg_positive_set_separate',
+		index(dnsmasq, 'nftset=/example.com/4#inet#fw4#pbr_wan_4_dst_ip_policy_domain,') >= 0]);
+
+	// Nothing anywhere may be a bare exclusion rule.
+	let bare = filter(lines, l => index(l, ' rule ') >= 0 && index(l, ' != ') >= 0 &&
+		index(l, 'saddr { ') < 0 && index(l, 'daddr { ') < 0 &&
+		index(l, 'iifname { ') < 0 && index(l, 'meta mark') < 0 &&
+		index(l, '@pbr_') < 0 && index(l, 'dport') < 0 && index(l, 'sport') < 0);
+	push(checks, ['no_bare_exclusion_rule_except_negonly', length(bare) == 1]);
+} else {
+	push(checks, ['nft_file_written', false]);
+}
+
+let pass = 0, fail = 0;
+for (let c in checks) {
+	if (c[1]) {
+		pass++;
+	} else {
+		fail++;
+		printf("FAIL: %s\n", c[0]);
+	}
+}
+printf("negation_on_same_rule: %d/%d passed\n", pass, pass + fail);
+-- End --
+
+-- File fs/stat~_sys_class_net_br-lan.json --
+{ "type": "link" }
+-- End --
+
+-- File uci/pbr.json --
+{
+	"pbr": [
+		{
+			".name": "config",
+			"enabled": "1",
+			"fw_mask": "00ff0000",
+			"ipv6_enabled": "1",
+			"resolver_set": "dnsmasq.nftset",
+			"strict_enforcement": "1",
+			"uplink_interface": "wan",
+			"uplink_interface6": "wan6",
+			"uplink_ip_rules_priority": "30000",
+			"uplink_mark": "00010000",
+			"verbosity": "2",
+			"lan_device": ["br-lan"],
+			"resolver_instance": ["*"],
+			"debug_performance": "0",
+			"nft_set_auto_merge": "1",
+			"nft_set_flags_interval": "1",
+			"nft_set_flags_timeout": "0",
+			"nft_set_policy": "performance",
+			"ignored_interface": ["vpnserver"]
+		}
+	],
+	"policy": [
+		// Positive entries of three different types plus two exclusions, one
+		// family-agnostic (MAC) and one IPv4-only.
+		{
+			".name": "policy_mixed",
+			"name": "Mixed",
+			"enabled": "1",
+			"interface": "wan",
+			"src_addr": "192.168.9.0/24 98:B8:BC:8B:3F:9E @br-lan !11:22:33:44:55:66 10.0.0.0/24 !10.0.0.22",
+			"chain": "prerouting"
+		},
+		// The documented standalone form: an exclusion with nothing to exclude
+		// it from still means "everything but this".
+		{
+			".name": "policy_negonly",
+			"name": "NegOnly",
+			"enabled": "1",
+			"interface": "wan",
+			"src_addr": "!10.0.0.99",
+			"chain": "prerouting"
+		},
+		{
+			".name": "policy_dest",
+			"name": "DestNeg",
+			"enabled": "1",
+			"interface": "wan",
+			"src_addr": "192.168.5.0/24",
+			"dest_addr": "10.10.0.0/16 !10.10.5.5",
+			"chain": "prerouting"
+		},
+		{
+			".name": "policy_domain",
+			"name": "DomainNeg",
+			"enabled": "1",
+			"interface": "wan",
+			"src_addr": "192.168.6.0/24",
+			"dest_addr": "example.com !blocked.example.com",
+			"chain": "prerouting"
+		}
+	]
+}
+-- End --
+
+-- Expect stdout --
+negation_on_same_rule: 19/19 passed
+-- End --

--- a/tests/lib/mocklib/fs.uc
+++ b/tests/lib/mocklib/fs.uc
@@ -1,5 +1,30 @@
 let mocklib = global.mocklib; // ucode-lsp disable
 
+let stat_path = function(path) { // ucode-lsp disable
+	/* Check captured content first */
+	if (mocklib.has_captured(path)) {
+		mocklib.trace_call("fs", "stat", { path, source: "captured" });
+		return { type: "file", size: length(mocklib.read_captured(path)) };
+	}
+
+	let file = sprintf("fs/stat~%s.json", replace(path, /[^A-Za-z0-9_-]+/g, '_')),
+	    mock = mocklib.read_json_file(file);
+
+	if (!mock || mock != mock) {
+		/* No fixture: return null to indicate "not found" by default.
+		 * For paths that look like directories, return directory type. */
+		if (match(path, /\/$/))
+			return { type: "directory" };
+		/* Most stat() calls in pbr check for existence — return null
+		 * unless there's a specific mock or captured content. */
+		return null;
+	}
+
+	mocklib.trace_call("fs", "stat", { path });
+
+	return mock;
+};
+
 return {
 	readfile: function(path, limit) {
 		/* Check captured content first (from mock writefile) */
@@ -83,30 +108,12 @@ return {
 		};
 	},
 
-	stat: function(path) {
-		/* Check captured content first */
-		if (mocklib.has_captured(path)) {
-			mocklib.trace_call("fs", "stat", { path, source: "captured" });
-			return { type: "file", size: length(mocklib.read_captured(path)) };
-		}
+	stat: stat_path,
 
-		let file = sprintf("fs/stat~%s.json", replace(path, /[^A-Za-z0-9_-]+/g, '_')),
-		    mock = mocklib.read_json_file(file);
-
-		if (!mock || mock != mock) {
-			/* No fixture: return null to indicate "not found" by default.
-			 * For paths that look like directories, return directory type. */
-			if (match(path, /\/$/))
-				return { type: "directory" };
-			/* Most stat() calls in pbr check for existence — return null
-			 * unless there's a specific mock or captured content. */
-			return null;
-		}
-
-		mocklib.trace_call("fs", "stat", { path });
-
-		return mock;
-	},
+	/* is_phys_dev() probes /sys/class/net/<dev> with lstat() because the entry
+	   is a symlink. pbr passes fs.lstat around as a bare function reference, so
+	   it must not depend on a receiver; fixtures are shared with stat(). */
+	lstat: stat_path,
 
 	unlink: function(path) {
 		mocklib.delete_captured(path);


### PR DESCRIPTION
## The bug

A negated entry in `src_addr`/`dest_addr` got a rule of its own, one per `*_negative` `filter_options` group:

```
ip saddr != { 10.0.0.22 } counter packets 24 bytes 1991 goto pbr_mark_0x010000 comment "phone-to-wan"
```

`nft` has no OR between the match expressions of a rule, so `pbr` needs one rule per positive address type — that is what makes a policy's address list a **union** of sources. Negated entries are the opposite: they are **AND** terms. On a rule of its own, `!10.0.0.22` reads as "every source except 10.0.0.22" — a catch-all that matches nearly everything, routes the whole network, and swallows exactly the traffic the policy was meant to leave alone. The counter above is from a real router: that rule took the entire chain's traffic, from an interface the policy does not even name.

`src_port`/`dest_port` negation was already built inline on the rule it belongs to, which is why `dest_port='!80'` always behaved correctly.

## The fix

Each policy's negated groups are resolved once, in the new `collect_negations()`, into the fragments appended to every rule the policy emits. `policy_process()` and `dns_policy_process()` now iterate the positive groups only and hand those fragments down to `policy_routing()` / `dns_policy_routing()`.

`classify_addr()` already keeps the families apart, so an IPv4 exclusion only ever reaches the IPv4 rule and vice versa. `matched` feeds the unknown-entry validation, so negated tokens are still not reported as unknown.

For `src_addr '192.168.9.0/24 98:B8:BC:8B:3F:9E @br-lan !11:22:33:44:55:66 10.0.0.0/24 !10.0.0.22'`, from the router:

```
iifname { "br-lan", "br-guest" } ether saddr != 11:22:33:44:55:66 ip saddr != 10.0.0.22 goto pbr_mark_0x010000
meta nfproto ipv6 iifname { "br-lan", "br-guest" } ether saddr != 11:22:33:44:55:66 goto pbr_mark_0x010000
ether saddr { 00:11:22:33:44:55, 98:b8:bc:8b:3f:9e } ether saddr != 11:22:33:44:55:66 ip saddr != 10.0.0.22 goto pbr_mark_0x010000
meta nfproto ipv6 ether saddr { 00:11:22:33:44:55, 98:b8:bc:8b:3f:9e } ether saddr != 11:22:33:44:55:66 goto pbr_mark_0x010000
ip saddr { 10.0.0.0/24, 192.168.9.0/24 } ether saddr != 11:22:33:44:55:66 ip saddr != 10.0.0.22 goto pbr_mark_0x010000
```

Positives OR across rules, exclusions AND within each.

### Why the family pinning

An `iifname` or `ether saddr` match reads the same for both families, so it is normally emitted once (the `param4 == param6` dedup). Attaching an IPv4-only exclusion splits it, and the two copies then **have** to be pinned with `meta nfproto` — otherwise the IPv6 copy, carrying no IPv4 exclusion, re-admits the very packets the IPv4 copy just filtered out, and the exclusion silently does nothing.

The guard is added only when the positive part is non-empty. A rule built from exclusions alone instead suppresses the family that has none, which keeps the documented standalone form (`dest_port '!80'`, "everything except these") behaving as before. `nft` does not print the redundant `meta nfproto ipv4` where an `ip` match already implies it, which is why only the IPv6 copies show it above.

## Second bug, fixed here too

For a negated domain, `classify_addr()` referenced a set named `<set>_neg` while `create_set()` and the `nftset=` line were keyed on the un-suffixed uid — so the set the rule pointed at was never created and never populated. That has been true since the shell implementation, where `nftset()` built the name from `$uid` and only the caller appended `$nftset_suffix`.

A policy mixing positive and negated domains was worse than ineffective: **all** of its domains, the excluded ones included, landed in the positive set, and the dangling `@<set>_neg` reference failed the `nft -c -f` check in `nft_file.apply()` — so the entire `pbr` ruleset was never installed, taking every other policy down with it.

The suffix is folded into the uid and the reference built with `get_set_name()`, so creation, dnsmasq population and the rule all derive one name. Confirmed on the router:

```
add set inet fw4 pbr_wan_4_dst_ip_cfg1a6ff5_neg { type ipv4_addr; ... }
nftset=/downloads.openwrt.org/4#inet#fw4#pbr_wan_4_dst_ip_cfg1a6ff5_neg,...
ip daddr @pbr_wan_4_dst_ip_cfg1a6ff5 ip daddr != @pbr_wan_4_dst_ip_cfg1a6ff5_neg goto pbr_mark_0x010000
```

The suffix is needed rather than removable: set names are keyed on the policy uid, not on the group within it, so without it a policy holding both a positive and a negated domain would emit `ip daddr @S ip daddr != @S`, which can never match.

## Upgrade path

On the old code a negated domain was fed into the **positive** set, so this fix changes that set's domain list — and #158's flush therefore empties it on the first reload after upgrade, clearing the wrongly-routed addresses by itself. No manual intervention, no reboot. That is why #158 went first.

## Tests

`tests/03_nft_rules/11_negation_on_same_rule` — 19 assertions: rule counts, every rule carrying a positive match, per-family exclusion placement, the `meta nfproto` pinning (present on the split copies, absent where an `ip` match already implies it), `dest_addr` exclusions, the negated-domain set being created *and* populated *and* referenced consistently, and a guard that no bare exclusion rule exists anywhere except the documented standalone form.

`tests/lib/mocklib/fs.uc` had no `lstat()` at all, so `is_phys_dev()` always returned false and `@device` entries could not be tested. `stat()` is hoisted to a module-level `stat_path()` with both aliased to it — it must not be a method, since `pbr` passes `fs.lstat` around as a bare function reference and would lose the receiver.

55/55 passing.

## Verification

Tested on the router: rule shapes, counters, the `_neg` sets being created and populated by dnsmasq, and the negated-domain policy loading where it previously failed the ruleset check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)