### PR TITLE
pbr-1.2.3: bump PKG_RELEASE from 87 to 89

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=pbr
 PKG_VERSION:=1.2.3
-PKG_RELEASE:=87
+PKG_RELEASE:=89
 PKG_LICENSE:=AGPL-3.0-or-later
 PKG_MAINTAINER:=Stan Grishin <stangri@melmac.ca>, Erik Conijn <egc112@msn.com>
 


### PR DESCRIPTION
Lockstep release bump with `luci-app-pbr`. Covers two fixes to how policies match, both of which silently sent traffic the wrong way:

- **Negated entries in `src_addr`/`dest_addr`** used to get an `nft` rule of their own, which on its own reads as "any source except this one" — a catch-all matching almost everything, so a policy mixing `192.168.1.0/24 !192.168.1.5` routed the whole network. They are now applied as exclusions on the policy's other entries. (#159)
- **Negated domain names in `dest_addr`** pointed at an `nft` set that was never created, which failed the ruleset check and stopped `pbr` installing any rules at all — so one such policy disabled all policy routing. (#159)
- **Editing the domain names in a policy** left the addresses the old ones had resolved to in the policy's set, so a domain removed from a policy kept being routed by it until reboot. (#158)

Upgrading is enough; no manual cleanup. The #158 flush clears the sets whose contents #159 changes, so a set mispopulated by the old code empties itself on the first reload.

Compat is unchanged at 36 — no message catalog change in this cycle — so neither package warns about a version mismatch, but they are released together as usual.

Paired with mossdef-org/luci-app-pbr#43.

🤖 Generated with [Claude Code](https://claude.com/claude-code)