### PR TITLE
pbr-1.2.3: keep the second uplink's chain name in step with its mark

### DIFF
--- a/files/lib/pbr/pbr.uc
+++ b/files/lib/pbr/pbr.uc
@@ -1113,6 +1113,15 @@ function create_pbr(fs_mod, uci_mod, ubus_mod) {
 				if (net.is_uplink4(iface) || net.is_uplink6(iface)) {
 					if (_uplink_mark && _uplink_priority) {
 						_mark = _uplink_mark;
+						// The chain name is derived from the mark above, so it
+						// has to follow the mark here as it does in the netifd
+						// and mwan4 branches. Left stale, the second uplink
+						// names the chain of whichever interface really owns
+						// the mark it no longer uses -- silently routing its
+						// traffic out that interface -- or, when no interface
+						// owns it, names a chain nobody creates, which fails
+						// the ruleset check and installs nothing at all.
+						_chain_name = pkg.nft_prefix + '_mark_' + _mark;
 						_priority = _uplink_priority;
 						split_uplink_second = true;
 					} else {

--- a/files/lib/pbr/pbr.uc
+++ b/files/lib/pbr/pbr.uc
@@ -1069,6 +1069,13 @@ function create_pbr(fs_mod, uci_mod, ubus_mod) {
 	// step: an interface whose mark is reassigned after the name was built ends up
 	// naming another interface's chain, or one nobody creates. Deriving both from
 	// here makes that structural rather than something each branch remembers.
+	//
+	// 'mark' is a '0x%06x' string. Every caller is already guaranteed one: it is
+	// either iface_mark, built by sprintf() below, or a netifd/mwan4 mark reached
+	// only through a branch that has tested it for truth. No coercion or fallback
+	// here on purpose -- a sentinel name would be created by nobody and routed to
+	// by nothing, turning a loud failure into the silent misroute this exists to
+	// prevent.
 	function mark_chain_name(mark) {
 		return pkg.nft_prefix + '_mark_' + mark;
 	}

--- a/files/lib/pbr/pbr.uc
+++ b/files/lib/pbr/pbr.uc
@@ -1065,6 +1065,14 @@ function create_pbr(fs_mod, uci_mod, ubus_mod) {
 	
 	// ── Enumerate Interfaces ────────────────────────────────────────────
 	
+	// The mark chain's name is derived from the mark, so the two must be kept in
+	// step: an interface whose mark is reassigned after the name was built ends up
+	// naming another interface's chain, or one nobody creates. Deriving both from
+	// here makes that structural rather than something each branch remembers.
+	function mark_chain_name(mark) {
+		return pkg.nft_prefix + '_mark_' + mark;
+	}
+
 	function interface_enumerate() {
 		config.uci_ctx('network', true);
 	
@@ -1099,13 +1107,13 @@ function create_pbr(fs_mod, uci_mod, ubus_mod) {
 			if (!dev6) dev6 = dev4;
 	
 			let _mark = iface_mark;
-			let _chain_name = pkg.nft_prefix + '_mark_' + _mark;
+			let _chain_name = mark_chain_name(_mark);
 			let _priority = _iface_priority;
 			let split_uplink_second = false;
 	
 			if (net.is_netifd_interface(iface) && env.netifd_mark[iface]) {
 				_mark = env.netifd_mark[iface];
-				_chain_name = pkg.nft_prefix + '_mark_' + _mark;
+				_chain_name = mark_chain_name(_mark);
 			} else if (net.is_mwan4_interface(iface) && env.mwan4_mark[iface]) {
 				_mark = env.mwan4_mark[iface];
 				_chain_name = env.mwan4_interface_chain[iface];
@@ -1121,7 +1129,7 @@ function create_pbr(fs_mod, uci_mod, ubus_mod) {
 						// traffic out that interface -- or, when no interface
 						// owns it, names a chain nobody creates, which fails
 						// the ruleset check and installs nothing at all.
-						_chain_name = pkg.nft_prefix + '_mark_' + _mark;
+						_chain_name = mark_chain_name(_mark);
 						_priority = _uplink_priority;
 						split_uplink_second = true;
 					} else {

--- a/tests/05_interfaces/13_split_uplink_chain_name
+++ b/tests/05_interfaces/13_split_uplink_chain_name
@@ -1,0 +1,110 @@
+Testing that both uplinks of a split uplink resolve to the same mark chain.
+
+With uplink_interface4 != uplink_interface6, the second uplink reached shares the
+first's firewall mark -- they share a routing table, so they must. Its chain name
+was derived from the mark it had *before* that reassignment and never recomputed,
+unlike the netifd and mwan4 branches beside it, so it named the chain of whichever
+interface really owns the mark it no longer uses.
+
+Two ways that goes wrong. If another interface owns that mark, a policy, a
+<iface>_dscp option or icmp_interface pointed at the second uplink silently routes
+out that interface instead. If nothing owns it, the chain is never created at all
+-- ensure_mark_chain() dedupes on mark, so the second uplink returns early -- and
+the ruleset carries a goto at a chain that does not exist, fails 'nft -c -f' and
+installs nothing.
+
+Which uplink is "second" is decided by section order in /etc/config/network, not
+by address family, so this can land on wan just as easily as on wan6.
+
+-- Testcase --
+import create_pbr from 'pbr';
+let pbr = create_pbr();
+
+pbr.start_service(['on_start']);
+
+let nft_content = global.mocklib.read_captured('/var/run/pbr.nft') || '';
+let lines = split(nft_content, '\n');
+let checks = [];
+
+// define pbr_<iface>_chain = pbr_mark_<mark>
+let chain_of = {};
+for (let l in lines) {
+	let m = match(l, /^define pbr_(\S+)_chain = (\S+)$/);
+	if (m) chain_of[m[1]] = m[2];
+}
+
+// Both uplinks share a routing table, so they must share a chain.
+push(checks, ['uplinks_share_a_chain', chain_of.wan && chain_of.wan == chain_of.wan6]);
+
+// And that chain must not be some other interface's.
+push(checks, ['uplink_chain_not_vpns', chain_of.wan != chain_of.vpn]);
+push(checks, ['vpn_has_its_own_chain', !!chain_of.vpn]);
+
+// No two interfaces may name the same chain unless they are the two uplinks.
+let seen = {}, collisions = 0;
+for (let iface in chain_of) {
+	let c = chain_of[iface];
+	if (seen[c] && !(iface == 'wan' || iface == 'wan6') ) collisions++;
+	if (seen[c] && (iface == 'wan' || iface == 'wan6') && !(seen[c] == 'wan' || seen[c] == 'wan6')) collisions++;
+	seen[c] = iface;
+}
+push(checks, ['no_unexpected_chain_collisions', collisions == 0]);
+
+// Every chain a rule jumps or gotos to has to be created somewhere in the file.
+// A dangling reference fails 'nft -c -f' and takes the whole ruleset with it.
+let created = {};
+for (let l in lines) {
+	let m = match(l, /^add chain inet fw4 (\S+)/);
+	if (m) created[m[1]] = true;
+}
+let dangling = [];
+for (let l in lines) {
+	let m = match(l, /goto (pbr_mark_\S+)/);
+	if (m && !created[m[1]]) push(dangling, m[1]);
+}
+push(checks, ['no_dangling_goto', length(dangling) == 0]);
+
+// The DSCP and ICMP rules are built from the same chain_name and are not
+// policy-driven, so they reach this with two config options and no policy.
+let dscp = filter(lines, l => index(l, 'dscp 10') >= 0);
+let icmp = filter(lines, l => index(l, 'protocol icmp') >= 0);
+push(checks, ['dscp_rules_emitted', length(dscp) == 2]);
+push(checks, ['icmp_rules_emitted', length(icmp) == 2]);
+push(checks, ['dscp_targets_uplink_chain',
+	length(filter(dscp, l => index(l, 'goto ' + chain_of.wan) >= 0)) == 2]);
+push(checks, ['icmp_targets_uplink_chain',
+	length(filter(icmp, l => index(l, 'goto ' + chain_of.wan) >= 0)) == 2]);
+
+let pass = 0, fail = 0;
+for (let c in checks) {
+	if (c[1]) {
+		pass++;
+	} else {
+		fail++;
+		printf("FAIL: %s\n", c[0]);
+	}
+}
+printf("split_uplink_chain_name: %d/%d passed\n", pass, pass + fail);
+-- End --
+
+-- File uci/pbr.json --
+{
+	"pbr": [
+		{
+			".name": "config", "enabled": "1", "fw_mask": "00ff0000", "ipv6_enabled": "1",
+			"resolver_set": "none", "strict_enforcement": "1",
+			"uplink_interface": "wan", "uplink_interface6": "wan6",
+			"wan6_dscp": "10", "icmp_interface": "wan6",
+			"uplink_ip_rules_priority": "30000", "uplink_mark": "00010000", "verbosity": "2",
+			"lan_device": ["br-lan"], "resolver_instance": ["*"], "debug_performance": "0",
+			"nft_set_auto_merge": "1", "nft_set_flags_interval": "1", "nft_set_flags_timeout": "0",
+			"nft_set_policy": "performance", "ignored_interface": ["vpnserver"]
+		}
+	],
+	"policy": []
+}
+-- End --
+
+-- Expect stdout --
+split_uplink_chain_name: 9/9 passed
+-- End --

--- a/tests/05_interfaces/14_split_uplink_no_dangling_chain
+++ b/tests/05_interfaces/14_split_uplink_no_dangling_chain
@@ -1,0 +1,89 @@
+Testing a split uplink with no other interface to own the second uplink's mark.
+
+This is the severe form of the same bug. ensure_mark_chain() dedupes on the mark,
+not on the chain name, so the second uplink of a split uplink -- which shares the
+first's mark -- returns early and never creates a chain under its own stale name.
+Where another interface happens to own that mark the result is a silent misroute;
+where nothing owns it, as on a plain wan + wan6 router with no tunnels, the name
+belongs to no chain at all.
+
+The ruleset then carries a goto at a chain that is never created, which fails the
+'nft -c -f' check in nft_file.apply(), so pbr installs no rules whatsoever and all
+policy routing stops. Two config options reach it and no policy is needed.
+
+nft does accept a goto at a chain declared later in the same batch -- confirmed on
+a router -- so file ordering alone is not the problem. The chain has to be absent.
+
+-- Testcase --
+import create_pbr from 'pbr';
+let pbr = create_pbr();
+
+pbr.start_service(['on_start']);
+
+let nft_content = global.mocklib.read_captured('/var/run/pbr.nft') || '';
+let lines = split(nft_content, '\n');
+let checks = [];
+
+let created = {};
+for (let l in lines) {
+	let m = match(l, /^add chain inet fw4 (\S+)/);
+	if (m) created[m[1]] = true;
+}
+
+// Only wan and wan6 are left, and they share a mark, so exactly one pbr_mark_
+// chain should exist.
+let mark_chains = filter(keys(created), c => index(c, 'pbr_mark_') == 0);
+push(checks, ['one_mark_chain_only', length(mark_chains) == 1]);
+
+// Every goto target must exist. This is the assertion that fails when the
+// second uplink keeps a chain name nobody creates.
+let dangling = [];
+for (let l in lines) {
+	let m = match(l, /goto (pbr_mark_\S+)/);
+	if (m && !created[m[1]]) push(dangling, m[1]);
+}
+push(checks, ['no_dangling_goto', length(dangling) == 0]);
+
+// The rules that get there without any policy.
+let dscp = filter(lines, l => index(l, 'dscp 10') >= 0);
+push(checks, ['dscp_rules_emitted', length(dscp) == 2]);
+push(checks, ['dscp_targets_a_created_chain',
+	length(filter(dscp, l => {
+		let m = match(l, /goto (pbr_mark_\S+)/);
+		return m && created[m[1]];
+	})) == 2]);
+
+let pass = 0, fail = 0;
+for (let c in checks) {
+	if (c[1]) {
+		pass++;
+	} else {
+		fail++;
+		printf("FAIL: %s\n", c[0]);
+	}
+}
+printf("split_uplink_no_dangling_chain: %d/%d passed\n", pass, pass + fail);
+-- End --
+
+-- File uci/pbr.json --
+{
+	"pbr": [
+		{
+			".name": "config", "enabled": "1", "fw_mask": "00ff0000", "ipv6_enabled": "1",
+			"resolver_set": "none", "strict_enforcement": "1",
+			"uplink_interface": "wan", "uplink_interface6": "wan6",
+			"wan6_dscp": "10",
+			"uplink_ip_rules_priority": "30000", "uplink_mark": "00010000", "verbosity": "2",
+			"lan_device": ["br-lan"], "resolver_instance": ["*"], "debug_performance": "0",
+			"nft_set_auto_merge": "1", "nft_set_flags_interval": "1", "nft_set_flags_timeout": "0",
+			"nft_set_policy": "performance",
+			"ignored_interface": ["vpnserver", "vpn", "wg0"]
+		}
+	],
+	"policy": []
+}
+-- End --
+
+-- Expect stdout --
+split_uplink_no_dangling_chain: 4/4 passed
+-- End --


### PR DESCRIPTION
## The bug

With `uplink_interface4 != uplink_interface6`, the second uplink reached shares the first's firewall mark — they share a routing table, so they must — but its chain name was derived from the mark it held *before* that reassignment and never recomputed. The netifd and mwan4 branches beside it both recompute; only this one does not. `split_uplink_second` suppresses the mark and priority increment and nothing else.

So the second uplink names the chain of whichever interface really owns the mark it no longer uses. From a live router:

```
define pbr_wan_chain         = pbr_mark_0x010000
define pbr_wan6_chain        = pbr_mark_0x020000   <- stale
define pbr_wg_mullv_se_chain = pbr_mark_0x020000   <- real owner
```

## Two ways it goes wrong, both reproduced

**Another interface owns the mark.** A policy, an `<iface>_dscp` option or `icmp_interface` pointed at the second uplink emits a `goto` at that interface's chain, so the traffic takes its mark and leaves by its table. Confirmed on a DL-WRX36: with `wan6_dscp=10` and a WireGuard tunnel present, DSCP-10 traffic was marked `0x020000` and routed out the tunnel instead of wan6. The ruleset installs cleanly and nothing is logged.

**Nothing owns it** — a plain `wan` + `wan6` router with no tunnels. `ensure_mark_chain()` dedupes on the mark, so the second uplink returns early and no chain is created under its stale name. The ruleset then carries a `goto` at a chain that does not exist, fails the `nft -c -f` check in `nft_file.apply()`, and **pbr installs no rules at all**. Two config options reach this and no policy is involved.

## Not specific to the IPv6 uplink

The branch keys on order of enumeration, so which uplink is "second" follows section order in `/etc/config/network`. With `wan6` listed first the stale name lands on **wan**, where an ordinary `option interface 'wan'` policy leaves by a tunnel.

## Scope is exactly this one field

Priorities and table ids are unaffected — both uplinks copy the same `_uplink_priority` and the counter only decrements when `!split_uplink_second`, and `interface_resolve_tid()` reads the other uplink's tid and reuses it. Diffing the emitted `ip rule` commands between the two enumeration orders gives identical sets with identical mark-to-priority pairings; only the sequence differs.

The non-split path already pairs every mark with its own chain, and netifd and mwan4 interfaces never reach this branch. `nft` accepts a `goto` at a chain declared later in the same batch (verified on the router), so file ordering alone is not a failure mode — the chain has to be genuinely absent.

## The fix

What the two branches above already do: recompute `_chain_name` when `_mark` changes.

## Tests

`tests/05_interfaces/13_split_uplink_chain_name` covers the first form — the uplinks share a chain, it is not the tunnel's, no two interfaces collide unexpectedly, no `goto` dangles, and the DSCP and ICMP rules target the uplink's chain. Without the fix it fails four of nine.

`tests/05_interfaces/14_split_uplink_no_dangling_chain` covers the second: every tunnel ignored, so nothing owns the mark. Exactly one `pbr_mark_` chain must exist and every `goto` target must be created. Without the fix it fails two of four.

Both drive it through `wan6_dscp` rather than a policy, to hold the tests to the fact that no policy is needed to reach this.

57/57 passing.

## Verification

Confirmed on the router: before the patch `nft list chain inet fw4 pbr_prerouting | grep dscp` gave `goto pbr_mark_0x020000` (the tunnel's chain); after, `goto pbr_mark_0x010000`, matching `define pbr_wan_chain`.

## Deliberately not included

Whether the IPv6 uplink should be selectable at all when `is_split_uplink()`. That is a design question, and reversed enumeration order weakens it as a remedy — the stale name can land on `wan`, which cannot be removed from the list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)