### PR TITLE
pbr-1.2.3: bump PKG_RELEASE from 89 to 91

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=pbr
 PKG_VERSION:=1.2.3
-PKG_RELEASE:=89
+PKG_RELEASE:=91
 PKG_LICENSE:=AGPL-3.0-or-later
 PKG_MAINTAINER:=Stan Grishin <stangri@melmac.ca>, Erik Conijn <egc112@msn.com>
 


### PR DESCRIPTION
Lockstep release bump with `luci-app-pbr`. Covers one fix (#161).

With a split uplink — `uplink_interface4` and `uplink_interface6` set to different interfaces — the second of the two shares the first's firewall mark, because they share a routing table. Its mark chain was still named after the mark it held before that, so it pointed at whichever interface really owns that mark.

Two ways that showed up:

- **Another interface owned the mark.** A policy, or a `<iface>_dscp` / `icmp_interface` option naming the second uplink, sent its traffic out that interface instead — silently, with nothing logged.
- **Nothing owned it** — a plain `wan` + `wan6` router with no tunnels. The chain was never created at all, the ruleset failed to load, and `pbr` installed no rules whatsoever.

Which of the two uplinks is affected follows section order in `/etc/config/network` rather than the address family, so on some routers this landed on `wan` and an ordinary wan policy left by a tunnel.

Upgrading is enough; no manual cleanup.

Compat is unchanged at 36 — no message catalog change in this cycle — so neither package warns about a version mismatch, but they are released together as usual.

Paired with mossdef-org/luci-app-pbr#44.

🤖 Generated with [Claude Code](https://claude.com/claude-code)