### PR TITLE
pbr-1.2.3: gate .uc syntax against the oldest supported ucode in CI

### DIFF
--- a/.github/workflows/ucode-syntax.yml
+++ b/.github/workflows/ucode-syntax.yml
@@ -7,6 +7,11 @@
 # UCODE_REF is the ucode shipped by OpenWrt 25.12 (package version
 # 2026.01.16~85922056). Bump it only when the oldest SUPPORTED OpenWrt release
 # moves — not when master moves.
+#
+# It MUST be the full 40-character SHA. `git fetch --depth 1 origin <sha>`
+# resolves an object id, not a ref, and an abbreviated hash fails with
+# "couldn't find remote ref". The OpenWrt package version only shows the short
+# form, so expand it before pasting it here.
 name: ucode syntax (oldest supported)
 
 on:
@@ -26,7 +31,7 @@ jobs:
   syntax:
     runs-on: ubuntu-latest
     env:
-      UCODE_REF: 85922056
+      UCODE_REF: 85922056ef7abeace3cca3ab28bc1ac2d88e31b1
       UCODE_REPO: https://github.com/jow-/ucode.git
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ucode-syntax.yml
+++ b/.github/workflows/ucode-syntax.yml
@@ -41,12 +41,15 @@ jobs:
         id: ucode-cache
         uses: actions/cache@v4
         with:
-          path: ucode-build
+          path: ${{ runner.temp }}/ucode-build
           key: ucode-${{ env.UCODE_REF }}-${{ runner.os }}
 
       - name: Build ucode at the oldest supported revision
         if: steps.ucode-cache.outputs.cache-hit != 'true'
         run: |
+          # Build outside the checkout: anything left in the workspace would be
+          # swept up by the file scan below.
+          cd "$RUNNER_TEMP"
           git init -q ucode-src && cd ucode-src
           git remote add origin "$UCODE_REPO"
           git fetch -q --depth 1 origin "$UCODE_REF"
@@ -59,4 +62,4 @@ jobs:
           cmake --build ucode-build -j"$(nproc)"
 
       - name: Compile every .uc file
-        run: tests/check-ucode-syntax.sh "$PWD/ucode-build/ucode"
+        run: tests/check-ucode-syntax.sh "$RUNNER_TEMP/ucode-build/ucode"

--- a/.github/workflows/ucode-syntax.yml
+++ b/.github/workflows/ucode-syntax.yml
@@ -1,4 +1,4 @@
-# Compile every .uc file with the OLDEST ucode pbr must support.
+# Compile every .uc file with the OLDEST ucode pbr must support. MANUAL ONLY.
 #
 # Newer ucode accepts everything older accepts, so a build that works on master
 # says nothing about the routers people run. This gate is deliberately pointed
@@ -14,17 +14,12 @@
 # form, so expand it before pasting it here.
 name: ucode syntax (oldest supported)
 
+# Manual only. CI minutes are scarce here, and the check earns its keep on
+# contributions from machines with a modern ucode -- where `{ foo() {...} }` and
+# `export function f() {}` work perfectly and break every 25.12 router. Run it
+# from the Actions tab when a PR touches .uc files, or locally with
+# `tests/check-ucode-syntax.sh <path-to-old-ucode>`.
 on:
-  push:
-    paths:
-      - '**/*.uc'
-      - 'tests/check-ucode-syntax.sh'
-      - '.github/workflows/ucode-syntax.yml'
-  pull_request:
-    paths:
-      - '**/*.uc'
-      - 'tests/check-ucode-syntax.sh'
-      - '.github/workflows/ucode-syntax.yml'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/ucode-syntax.yml
+++ b/.github/workflows/ucode-syntax.yml
@@ -1,0 +1,62 @@
+# Compile every .uc file with the OLDEST ucode pbr must support.
+#
+# Newer ucode accepts everything older accepts, so a build that works on master
+# says nothing about the routers people run. This gate is deliberately pointed
+# at the old interpreter.
+#
+# UCODE_REF is the ucode shipped by OpenWrt 25.12 (package version
+# 2026.01.16~85922056). Bump it only when the oldest SUPPORTED OpenWrt release
+# moves — not when master moves.
+name: ucode syntax (oldest supported)
+
+on:
+  push:
+    paths:
+      - '**/*.uc'
+      - 'tests/check-ucode-syntax.sh'
+      - '.github/workflows/ucode-syntax.yml'
+  pull_request:
+    paths:
+      - '**/*.uc'
+      - 'tests/check-ucode-syntax.sh'
+      - '.github/workflows/ucode-syntax.yml'
+  workflow_dispatch:
+
+jobs:
+  syntax:
+    runs-on: ubuntu-latest
+    env:
+      UCODE_REF: 85922056
+      UCODE_REPO: https://github.com/jow-/ucode.git
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends \
+            build-essential cmake libjson-c-dev libmd-dev
+
+      - name: Cache the ucode build
+        id: ucode-cache
+        uses: actions/cache@v4
+        with:
+          path: ucode-build
+          key: ucode-${{ env.UCODE_REF }}-${{ runner.os }}
+
+      - name: Build ucode at the oldest supported revision
+        if: steps.ucode-cache.outputs.cache-hit != 'true'
+        run: |
+          git init -q ucode-src && cd ucode-src
+          git remote add origin "$UCODE_REPO"
+          git fetch -q --depth 1 origin "$UCODE_REF"
+          git checkout -q FETCH_HEAD
+          cd ..
+          # Modules are irrelevant to a syntax check and need OpenWrt libraries.
+          cmake -S ucode-src -B ucode-build -DCMAKE_BUILD_TYPE=Release \
+                -DRTNL_SUPPORT=OFF -DNL80211_SUPPORT=OFF \
+                -DUBUS_SUPPORT=OFF -DUCI_SUPPORT=OFF
+          cmake --build ucode-build -j"$(nproc)"
+
+      - name: Compile every .uc file
+        run: tests/check-ucode-syntax.sh "$PWD/ucode-build/ucode"

--- a/tests/check-ucode-syntax.sh
+++ b/tests/check-ucode-syntax.sh
@@ -1,0 +1,78 @@
+#!/bin/sh
+#
+# check-ucode-syntax.sh — compile every .uc file with a given ucode binary.
+#
+# Catches syntax that is too NEW for the oldest ucode pbr must support. Newer
+# ucode accepts everything older accepts, so building against master proves
+# nothing about the routers people actually run — point this at the OLDEST
+# supported interpreter.
+#
+# Usage: tests/check-ucode-syntax.sh [path-to-ucode]     (default: ucode in PATH)
+#
+# Files are classified by whether they contain a top-level `export`:
+#   module -> must be reached through an `import` wrapper; compiling one
+#             directly stops at the first export with "Exports may only appear
+#             at top level of a module", which is NOT a real failure.
+#   script -> compiled directly; these use top-level `return` and are rejected
+#             by the import wrapper on every version.
+# Getting this backwards produces confident nonsense in both directions.
+#
+set -u
+
+UCODE="${1:-ucode}"
+command -v "$UCODE" >/dev/null 2>&1 || { echo "no ucode at '$UCODE'" >&2; exit 2; }
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+echo "ucode: $UCODE"
+"$UCODE" -e 'print("")' 2>/dev/null || { echo "ucode not runnable" >&2; exit 2; }
+
+# ---------------------------------------------------------------------------
+# Canary: prove this check is capable of failing. A scan that cannot fail is
+# not evidence — an earlier version of this reported "all files compile" while
+# actually iterating over an empty directory.
+# ---------------------------------------------------------------------------
+printf 'let o = { shorthand() { return 1; } };\nexport default o;\n' > "$TMP/canary.uc"
+echo "import * as m from \"$TMP/canary.uc\";" > "$TMP/w.uc"
+if "$UCODE" -c -o /dev/null "$TMP/w.uc" >/dev/null 2>&1; then
+	echo "CANARY PASSED — this ucode accepts shorthand methods, so it is NOT an"
+	echo "old-enough interpreter to be a useful compatibility gate." >&2
+	exit 2
+fi
+echo "canary: correctly rejected (check is live)"
+
+n=0; bad=0
+
+# Read the file list from a temp file rather than a pipeline: a `find | while`
+# pipeline runs the loop in a subshell under POSIX sh, and the counters below
+# would be lost when it exits. Redirecting from a file keeps the loop in this
+# shell. (Filenames containing newlines would still break this; none do, and
+# `find -print0` needs `read -d` which is not POSIX.)
+find "$ROOT" -name '*.uc' | sort > "$TMP/files.txt"
+
+while IFS= read -r f; do
+	[ -n "$f" ] || continue
+	n=$((n + 1))
+	rel="${f#$ROOT/}"
+
+	if grep -qE '^[[:space:]]*export' "$f"; then
+		echo "import * as m from \"$f\";" > "$TMP/w.uc"
+		target="$TMP/w.uc"; kind="module"
+	else
+		target="$f"; kind="script"
+	fi
+
+	if err="$("$UCODE" -c -o /dev/null "$target" 2>&1)"; then
+		printf '  ok   %-8s %s\n' "$kind" "$rel"
+	else
+		bad=$((bad + 1))
+		printf '  FAIL %-8s %s\n' "$kind" "$rel"
+		echo "$err" | sed 's/^/         /' | head -4
+	fi
+done < "$TMP/files.txt"
+
+echo
+echo "checked $n file(s), $bad failed"
+[ "$bad" -eq 0 ] || exit 1

--- a/tests/check-ucode-syntax.sh
+++ b/tests/check-ucode-syntax.sh
@@ -45,12 +45,22 @@ echo "canary: correctly rejected (check is live)"
 
 n=0; bad=0
 
-# Read the file list from a temp file rather than a pipeline: a `find | while`
-# pipeline runs the loop in a subshell under POSIX sh, and the counters below
-# would be lost when it exits. Redirecting from a file keeps the loop in this
-# shell. (Filenames containing newlines would still break this; none do, and
-# `find -print0` needs `read -d` which is not POSIX.)
-find "$ROOT" -name '*.uc' | sort > "$TMP/files.txt"
+# List only files the REPOSITORY owns. `find` over the working tree also picks
+# up anything else that happens to be there -- CI clones the ucode source into
+# the workspace, and upstream's own tests/custom/*.uc are not ours to compile.
+# git ls-files covers tracked plus untracked-but-not-ignored, so a new file is
+# still checked before it is committed.
+if git -C "$ROOT" rev-parse --git-dir >/dev/null 2>&1; then
+	git -C "$ROOT" ls-files --cached --others --exclude-standard '*.uc' \
+		| sed "s|^|$ROOT/|" | sort > "$TMP/files.txt"
+else
+	find "$ROOT" -name '*.uc' | sort > "$TMP/files.txt"
+fi
+
+# Read from a file rather than a pipeline: a `find | while` pipeline runs the
+# loop in a subshell under POSIX sh, and the counters below would be lost when
+# it exits. (Filenames containing newlines would still break this; none do, and
+# `find -print0` needs `read -d`, which is not POSIX.)
 
 while IFS= read -r f; do
 	[ -n "$f" ] || continue


### PR DESCRIPTION
## Why

pbr has to load on the oldest ucode it supports **and** on master. Newer ucode accepts everything older accepts, so a tree that builds against master says nothing about the interpreter on the routers people actually run.

Two constructs already differ, and both are hard syntax errors on the ucode shipped in OpenWrt 25.12 (`2026.01.16~85922056`):

- object-literal shorthand methods — `{ foo() {...} }` — merged upstream 2026-06-22
- `export function f() {}` without a trailing `;` — fixed by `552ca3c`, 2026-02-11

Either makes the whole file fail to compile on a stock 25.12 router while passing every check on a modern build. pbr is clean today; this is about keeping it that way — particularly for contributions written on machines with a current ucode, where both constructs work perfectly.

## What

- `tests/check-ucode-syntax.sh` — compiles every `.uc` file with a given ucode binary
- `.github/workflows/ucode-syntax.yml` — **`workflow_dispatch` only**; builds ucode at `85922056…` and runs the script

**Manual by design.** No push or pull_request trigger, so it costs no CI minutes until someone runs it from the Actions tab. It can also be run locally at any time:

```sh
tests/check-ucode-syntax.sh /path/to/old/ucode
```

## Two details worth reviewing

**File classification.** Files carrying a top-level `export` are modules and must be reached through an `import` wrapper — compiling one directly stops at the first export with *"Exports may only appear at top level of a module"*, which is not a real failure. Everything else is a script, uses top-level `return`, and is rejected by that wrapper on every version. Getting this backwards produces confident nonsense in both directions.

**The canary.** The script first compiles a file using a shorthand method, which the old interpreter must reject. If it compiles, the check exits non-zero instead of passing. Without this, pointing `UCODE_REF` at a modern ucode would turn the check into a green tick that means nothing.

## Note on reproducibility

This workflow pins `UCODE_REF` to a full 40-character SHA and fetches that object, so upstream ucode moving cannot change its result.

Worth contrasting with `openwrt-release.yml:25`, which clones ucode unpinned:

```yaml
git clone --depth 1 https://github.com/jow-/ucode.git /tmp/ucode
```

so the functional suite currently runs against whatever master is on the day — a version no router has, and one where every trap this check guards against is already fixed. Pinning that clone would be a separate, small change.

## Scope

Catches syntax that is too new. Does **not** catch behavioural differences that compile fine and misbehave at runtime — `fs.popen([...])` returning `EINVAL`, `(-n) ** even` giving the wrong sign, `lc()`/`uc()`/`reverse()` truncating at a NUL. Those need the test suite run against an old ucode, which is a larger change.

## Testing

Run against a local build of `85922056`: 17 files, 0 failures, canary correctly rejected. Verified the file walk handles paths containing spaces. The workflow itself has not had a clean CI run — the first attempt failed on an abbreviated SHA (fixed in `f0bbb5a`) and the re-run wedged on `apt-get` for 30+ minutes, as did `openwrt-release.yml` on the same push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
