### PR TITLE
pbr.user.dnsprefetch: make it work on the ucode service again

### DIFF
--- a/files/usr/share/pbr/pbr.user.dnsprefetch
+++ b/files/usr/share/pbr/pbr.user.dnsprefetch
@@ -6,6 +6,25 @@
 # on the shell implementation (1.2.2 and earlier), which ships its own copy of
 # this file -- use that one there.
 #
+# WHEN IT RUNS: once per full pbr run -- start, restart and reload. Not on the
+# on_boot pass, not on a start deferred because the uplink is down, and not on
+# stop. Overlapping runs are harmless: each detached copy makes its own
+# $$-suffixed fifo.
+#
+# An interface event (a wan flap) does NOT run it. That path reloads the
+# interfaces and returns; user files, the ruleset rewrite and the resolver step
+# all sit in the branch it skips. It only prefetches when pbr promotes the event
+# to a full start, which it does when its ruleset is not installed, when procd
+# reports no gateways, or when the last run recorded errors. So the sets are
+# refilled after the reload that follows a flap, not by the flap itself.
+#
+# There is no timer. Nothing re-resolves a name once its TTL expires and
+# dnsmasq drops it from the cache, so a set keeps the addresses it got until
+# the next pbr run. That is inherent to a prefetch rather than a refresher; a
+# domain that rotates addresses faster than pbr reloads needs a cron job
+# reloading pbr, which reprocesses everything and is worth it only if stale
+# routing actually shows up.
+#
 # pbr sources this file from a bare shell that exports none of the service's
 # internal variables, so everything needed is defined below. In particular do
 # not reintroduce $packageName, $packageDnsmasqFile or $resolverSetSupported:

--- a/files/usr/share/pbr/pbr.user.dnsprefetch
+++ b/files/usr/share/pbr/pbr.user.dnsprefetch
@@ -124,10 +124,23 @@ else
 	# here and only got through because a failing nslookup costs more than the
 	# 1s sleep. Waiting longer is free: the loop exits as soon as dnsmasq
 	# answers, and nothing else is waiting on it.
+	#
+	# Any reply proves that, including a negative one -- so do not test the exit
+	# status. busybox nslookup returns 1 for NXDOMAIN exactly as it does for a
+	# resolver that never answered, and 'localhost' comes from /etc/hosts, which
+	# dnsmasq does not read when its nohosts option is set. Waiting for rc=0
+	# would then never succeed and the prefetch would abort against a perfectly
+	# healthy resolver. A DNS response code in the output means dnsmasq is
+	# serving; a resolver that is not there prints 'Connection refused' and
+	# 'connection timed out' instead, with no response code, so the match stays
+	# case-sensitive.
 	dnsmasq_ready() {
 		local timeout_dnsmasq='90'
+		local reply
 
-		while ! nslookup 'localhost' 127.0.0.1 >/dev/null 2>&1; do
+		while :; do
+			reply="$(nslookup 'localhost' 127.0.0.1 2>&1)" && return 0
+			printf '%s' "$reply" | grep -qE 'NXDOMAIN|SERVFAIL|REFUSED' && return 0
 			[ "$timeout_dnsmasq" -eq '0' ] && return 1
 			sleep '1' && timeout_dnsmasq="$((timeout_dnsmasq - 1))"
 		done

--- a/files/usr/share/pbr/pbr.user.dnsprefetch
+++ b/files/usr/share/pbr/pbr.user.dnsprefetch
@@ -44,8 +44,16 @@
 _dnsprefetch_self='/usr/share/pbr/pbr.user.dnsprefetch'
 
 if [ -z "$PBR_DNSPREFETCH_CHILD" ]; then
-	[ -f "$_dnsprefetch_self" ] &&
+	if [ -f "$_dnsprefetch_self" ]; then
 		PBR_DNSPREFETCH_CHILD=1 setsid /bin/sh "$_dnsprefetch_self" </dev/null >/dev/null 2>&1 &
+	else
+		# The only failure this script cannot report from the detached copy,
+		# since there is nothing to detach. pbr logs that it ran the file but
+		# never what the file did, so without this line a prefetch that was
+		# installed somewhere else is skipped in silence -- which is exactly
+		# how this script used to fail.
+		logger -t "pbr [$$]" "WARNING: $_dnsprefetch_self not found, domain names in policies not resolved [✗]"
+	fi
 else
 	packageName='pbr'
 	packageDnsmasqFile="/var/run/${packageName}.dnsmasq"

--- a/files/usr/share/pbr/pbr.user.dnsprefetch
+++ b/files/usr/share/pbr/pbr.user.dnsprefetch
@@ -1,17 +1,70 @@
 #!/bin/sh
 # When using pbr with dnsmasq's nft set support, a domain-based policy will not take effect until
 # the remote domain name has been resolved by dnsmasq. Resolve all domain names in pbr policies in advance.
+#
+# REQUIRES THE UCODE IMPLEMENTATION OF PBR (1.2.3 AND LATER). It will not work
+# on the shell implementation (1.2.2 and earlier), which ships its own copy of
+# this file -- use that one there.
+#
+# pbr sources this file from a bare shell that exports none of the service's
+# internal variables, so everything needed is defined below. In particular do
+# not reintroduce $packageName, $packageDnsmasqFile or $resolverSetSupported:
+# they are unset here and the script would silently do nothing. (The shell
+# implementation sourced user files into its own shell, where they were in
+# scope; the ucode service runs them in a child process, which drops them.)
 # shellcheck disable=SC3043
 
-(
+# pbr waits for every process this file leaves running -- a plain "&" is not
+# enough, and a background job that waits for pbr to finish deadlocks it (a 60s
+# wait here made "/etc/init.d/pbr reload" take 62s instead of 3s). So the first
+# pass only re-executes this file in its own session and returns immediately;
+# all of the real work happens in that detached copy, after pbr has moved on.
+#
+# The service sources this file, so it cannot discover its own path ($0 is the
+# sourcing shell). Update this if you install it somewhere else.
+_dnsprefetch_self='/usr/share/pbr/pbr.user.dnsprefetch'
+
+if [ -z "$PBR_DNSPREFETCH_CHILD" ]; then
+	[ -f "$_dnsprefetch_self" ] &&
+		PBR_DNSPREFETCH_CHILD=1 setsid /bin/sh "$_dnsprefetch_self" </dev/null >/dev/null 2>&1 &
+else
+	packageName='pbr'
+	packageDnsmasqFile="/var/run/${packageName}.dnsmasq"
+	packageNftFile="/usr/share/nftables.d/ruleset-post/30-${packageName}.nft"
 	pipe_nslookup="/var/run/${packageName}.nslookup.$$"
+	_WARNING_='WARNING:'
+	__OK__='[✓]'
+	__FAIL__='[✗]'
 
 	output() {
 		local msg="$*"
 
 		msg="$(printf '%b' "$msg" | sed 's/\x1b\[[0-9;]*m//g')"
-		# shellcheck disable=SC2154
 		logger -t "$packageName [$$]" "$(printf '%b' "$msg")"
+	}
+
+	# Modification time of the ruleset pbr installs, or the empty string before
+	# the first one exists.
+	nft_stamp() {
+		[ -f "$packageNftFile" ] || return 0
+		date -r "$packageNftFile" +%s 2>/dev/null
+	}
+
+	# nft_file.apply('main') rewrites the ruleset on every start and reload, so
+	# its mtime changing means pbr has installed the new generation and the sets
+	# are live. The lock file looks like a tidier signal but is useless here:
+	# reload_service() never calls service_started(), so it keeps the pid it was
+	# given at boot. Waiting on a dnsmasq restart is no good either -- a reload
+	# only restarts dnsmasq when /var/run/pbr.dnsmasq changed, and takes the
+	# quieter SIGHUP cache flush otherwise.
+	nft_file_installed() {
+		local timeout_nft_file='60'
+		local stamp_before="$1"
+
+		while [ "$(nft_stamp)" = "$stamp_before" ]; do
+			[ "$timeout_nft_file" -eq '0' ] && return 1
+			sleep '1' && timeout_nft_file="$((timeout_nft_file - 1))"
+		done
 	}
 
 	nft_ready() {
@@ -25,12 +78,25 @@
 		done
 	}
 
+	# A SIGHUP delivered before dnsmasq installs its handler terminates it --
+	# that is the default action for the signal -- and pbr may still be
+	# restarting it when we get here. Answering a query proves it is past
+	# initialisation and safe to signal.
+	dnsmasq_ready() {
+		local timeout_dnsmasq='30'
+
+		while ! nslookup 'localhost' 127.0.0.1 >/dev/null 2>&1; do
+			[ "$timeout_dnsmasq" -eq '0' ] && return 1
+			sleep '1' && timeout_dnsmasq="$((timeout_dnsmasq - 1))"
+		done
+	}
+
 	run_nslookup() {
 		local output reason
 
 		output="$(nslookup "$1" 127.0.0.1)" && { echo '0' > "$pipe_nslookup"; return; }
 		reason="$(printf '%s' "$output" | grep -Eo -m 1 'NXDOMAIN|SERVFAIL|timed out')" && \
-		output "$_WARNING_ Lookup failed for $domain ($reason)"
+		output "$_WARNING_ Lookup failed for $1 ($reason)"
 		echo '1' > "$pipe_nslookup"
 	}
 
@@ -46,61 +112,69 @@
 	}
 
 	main() {
-		local pipe_ubus="/var/run/${packageName}.ubus.$$"
-		local timeout_dnsmasq='20'
 		local msg_abort='domain names in policies not resolved'
-		local dnsmasq_restarted ubus_listen_pid event domain entries
+		local settle='5'
+		local stamp_before domain
 		local rc='0'
 
-		[ -n "$resolverSetSupported" ] || {
+		# $resolverSetSupported is not available here; read the setting pbr
+		# itself acts on instead. Anything but dnsmasq.nftset means there are
+		# no sets for a prefetch to fill.
+		[ "$(uci -q get "${packageName}.config.resolver_set")" = 'dnsmasq.nftset' ] || {
 			output "Resolver set support disabled, $msg_abort $__FAIL__"
-			rc='1'
-			return "$rc"
+			return 1
 		}
-		mkfifo "$pipe_ubus"
-		mkfifo "$pipe_nslookup"
-		# The subshell may be necessary for "$!" to expand to a correct value
-		( exec ubus listen -m 'ubus.object.add' > "$pipe_ubus" ) &
-		ubus_listen_pid="$!"
 
-		# shellcheck disable=SC3045
-		while read -t "$timeout_dnsmasq" -r event; do
-			echo "$event" | grep -q "dnsmasq.dns" || continue
-			dnsmasq_restarted='1'
-			# shellcheck disable=SC2154
-			[ -f "$packageDnsmasqFile" ] || {
-				output "File $packageDnsmasqFile not found, $msg_abort $__FAIL__"
-				rc='1'
-				break
-			}
-			nft_ready || {
-				output "Pbr's nft sets not found, $msg_abort $__FAIL__"
-				rc='1'
-				break
-			}
+		stamp_before="$(nft_stamp)"
+		# Nothing else cleans this up if the prefetch is killed part-way.
+		trap 'rm -f "$pipe_nslookup"' EXIT HUP INT TERM
+		mkfifo "$pipe_nslookup"
+
+		nft_file_installed "$stamp_before" || {
+			output "Timed out waiting for $packageName to install its ruleset, $msg_abort $__FAIL__"
+			rc='1'
+		}
+		# Give pbr the rest of its run: it reaps orphaned sets and drops
+		# addresses for domains whose policy changed just after installing the
+		# ruleset, and either of those would discard what we resolve here.
+		[ "$rc" -eq '0' ] && sleep "$settle"
+		[ "$rc" -eq '0' ] && [ ! -f "$packageDnsmasqFile" ] && {
+			output "File $packageDnsmasqFile not found, $msg_abort $__FAIL__"
+			rc='1'
+		}
+		[ "$rc" -eq '0' ] && ! nft_ready && {
+			output "Pbr's nft sets not found, $msg_abort $__FAIL__"
+			rc='1'
+		}
+
+		[ "$rc" -eq '0' ] && ! dnsmasq_ready && {
+			output "Dnsmasq is not answering, $msg_abort $__FAIL__"
+			rc='1'
+		}
+
+		[ "$rc" -eq '0' ] && {
+			# dnsmasq only writes to an nft set on an upstream reply, so a name
+			# still in its cache would be answered without filling the set.
+			# pbr has already cleared the cache by this point on both of its
+			# paths, but doing it here too costs nothing and keeps this correct
+			# whichever path ran, and whatever the timing. Only ever after
+			# dnsmasq_ready() -- see the note there.
+			killall -q -s HUP dnsmasq
+			sleep '1'
 			nslookup_tracker & exec 3>"$pipe_nslookup"
 			(
 				output "Resolving domain names in policies..."
 				while IFS='/' read -r _ domain _; do
 					[ -n "$domain" ] && run_nslookup "$domain" &
-					entries="$((entries + 1))"
 				done < "$packageDnsmasqFile"
 				wait
 			)
 			exec 3>&-
-			break
-		done < "$pipe_ubus"
-
-		[ -n "$dnsmasq_restarted" ] || {
-			output "Dnsmasq hasn't restarted, $msg_abort $__FAIL__"
-			rc='1'
 		}
-		kill "$ubus_listen_pid"
-		rm -f "$pipe_ubus"
+
 		rm -f "$pipe_nslookup"
 		return "$rc"
 	}
-	
+
 	main
-	return "$?"
-) &
+fi

--- a/files/usr/share/pbr/pbr.user.dnsprefetch
+++ b/files/usr/share/pbr/pbr.user.dnsprefetch
@@ -70,6 +70,13 @@ else
 		logger -t "$packageName [$$]" "$(printf '%b' "$msg")"
 	}
 
+	# Every timeout below is an iteration count, not a wall-clock second: each
+	# turn costs its own work plus the 1s sleep, so a failing nslookup makes a
+	# turn cost several seconds. They are sized for the slowest router that
+	# might run this, and being generous is free -- each loop returns the
+	# moment its condition is met, so a fast router never spends the budget.
+	# Only a genuine failure waits it out, and then the abort is logged.
+	#
 	# Modification time of the ruleset pbr installs, or the empty string before
 	# the first one exists.
 	nft_stamp() {
@@ -85,7 +92,7 @@ else
 	# only restarts dnsmasq when /var/run/pbr.dnsmasq changed, and takes the
 	# quieter SIGHUP cache flush otherwise.
 	nft_file_installed() {
-		local timeout_nft_file='60'
+		local timeout_nft_file='180'
 		local stamp_before="$1"
 
 		while [ "$(nft_stamp)" = "$stamp_before" ]; do
@@ -95,7 +102,7 @@ else
 	}
 
 	nft_ready() {
-		local timeout_nft='10'
+		local timeout_nft='30'
 
 		while ! /usr/sbin/nft list sets 'inet' | grep -q "pbr"; do
 			[ "$timeout_nft" -eq '0' ] && {
@@ -109,8 +116,16 @@ else
 	# that is the default action for the signal -- and pbr may still be
 	# restarting it when we get here. Answering a query proves it is past
 	# initialisation and safe to signal.
+	#
+	# The budget has to cover a boot, not a reload. On a boot pbr can spend
+	# tens of seconds between installing the ruleset (which releases the wait
+	# below) and restarting dnsmasq last of all -- a policy that fetches a URL
+	# is enough to do it. One observed boot spent 33s of a 30-iteration budget
+	# here and only got through because a failing nslookup costs more than the
+	# 1s sleep. Waiting longer is free: the loop exits as soon as dnsmasq
+	# answers, and nothing else is waiting on it.
 	dnsmasq_ready() {
-		local timeout_dnsmasq='30'
+		local timeout_dnsmasq='90'
 
 		while ! nslookup 'localhost' 127.0.0.1 >/dev/null 2>&1; do
 			[ "$timeout_dnsmasq" -eq '0' ] && return 1
@@ -140,7 +155,7 @@ else
 
 	main() {
 		local msg_abort='domain names in policies not resolved'
-		local settle='5'
+		local settle='15'
 		local stamp_before domain
 		local rc='0'
 
@@ -164,6 +179,11 @@ else
 		# Give pbr the rest of its run: it reaps orphaned sets and drops
 		# addresses for domains whose policy changed just after installing the
 		# ruleset, and either of those would discard what we resolve here.
+		# Both are a handful of nft calls issued right after the ruleset goes
+		# in, so this does not have to cover pbr's slow work -- the two long
+		# waits either side of it do. It is padded for a slow router all the
+		# same, and costs nothing on a fast one: it runs in the detached copy,
+		# never in the reload.
 		[ "$rc" -eq '0' ] && sleep "$settle"
 		[ "$rc" -eq '0' ] && [ ! -f "$packageDnsmasqFile" ] && {
 			output "File $packageDnsmasqFile not found, $msg_abort $__FAIL__"


### PR DESCRIPTION
`pbr.user.dnsprefetch` has been a silent no-op since the ucode rewrite, and reported success while doing nothing. Four commits: the fix, its header documentation, a warning for the one remaining silent path, and timeout budgets sized for slow hardware.

### Why it did nothing

pbr sources `.sh` user files from a bare shell that exports none of the service's internals (`pbr.uc` → `sys.run` → `system()`), so `$resolverSetSupported` was empty and `main()` bailed at its first gate. Because the body was backgrounded, that failure never reached `sh.run` either: pbr logged `Running ... [OK]` while nothing had happened, and the abort line went to syslog under an empty tag. It ships `enabled '0'`, which is why nobody reported it.

The trigger was broken independently. It armed on a dnsmasq restart via ubus, but since #155 a no-change reload takes the quieter SIGHUP cache flush, so the common path always timed out. Worse, pbr waits for every process a user file leaves running, so waiting for pbr's own progress deadlocks it — a 60s timeout made `/etc/init.d/pbr reload` take 62s instead of 3s.

### What it does now

Re-exec under `setsid` so the reload returns immediately, then watch the mtime of the installed ruleset, settle, and resolve. SIGHUP dnsmasq first so a cached name still reaches its set — but only once it answers a query, because the default action for SIGHUP is terminate and signalling it mid-restart killed the daemon outright on test hardware.

The script defines what it needs locally rather than inheriting it, and reads `pbr.config.resolver_set` for the gate `$resolverSetSupported` used to provide.

### Validation

On a DL-WRX36 running 1.2.3-r91, sets emptied before each run:

- no-change reload (SIGHUP branch) and forced restart — 6/6 domains resolved, sets refilled, reload unaffected
- self-path pointing at a missing file — warning logged, reload not slowed, service stays active
- two reloads 3s apart — both workers complete, no fifo or process leaks
- interface-reload trigger — does **not** prefetch, which is now documented; it does when pbr promotes the event to a full start, verified by clearing pbr's chains
- three reboots — nothing on the `on_boot` pass, nothing on a start deferred with the uplink down, 6/6 on each real start

Those boots also showed dnsmasq answering up to 33s after pbr logs `Restarting dnsmasq [OK]`, against a 30-iteration budget — hence the last commit.

Scoped to `files/usr/share/pbr/pbr.user.dnsprefetch`. Requires the ucode implementation; 1.2.2 keeps its own copy. No `PKG_RELEASE` bump here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)