### PR TITLE
pbr-1.2.3: pass ip(2) an argument vector instead of a shell string

### DIFF
--- a/files/lib/pbr/config.uc
+++ b/files/lib/pbr/config.uc
@@ -145,6 +145,13 @@ function create_config(uci_mod, ubus_mod, pkg) {
 		if (!match('' + cfg.procd_boot_trigger_delay, /^[0-9]+$/)) cfg.procd_boot_trigger_delay = '5000';
 		if (int(cfg.procd_boot_trigger_delay) < 1000) cfg.procd_boot_trigger_delay = '1000';
 
+		// suppress_prefixlength is interpolated into an `ip rule` command line,
+		// so it must be a bare number. UCI declares it a string with no bound,
+		// which let arbitrary text through to the shell. 0-128 is the protocol
+		// maximum; `ip -4` rejects anything above 32 on its own.
+		if (!match('' + cfg.prefixlength, /^[0-9]+$/)) cfg.prefixlength = '1';
+		if (int(cfg.prefixlength) > 128) cfg.prefixlength = '128';
+
 		if (!match('' + cfg.uplink_ip_rules_priority, /^[0-9]+$/)) cfg.uplink_ip_rules_priority = '30000';
 		if (int(cfg.uplink_ip_rules_priority) < 99) cfg.uplink_ip_rules_priority = '99';
 		if (int(cfg.uplink_ip_rules_priority) > 32765) cfg.uplink_ip_rules_priority = '32765';

--- a/files/lib/pbr/nft.uc
+++ b/files/lib/pbr/nft.uc
@@ -690,10 +690,10 @@ function create_nft(fs_mod, config, sh, output, pkg, platform, network, V, state
 							let tm = match(line, /lookup\s+(\S+)/);
 							if (tm && network.is_netifd_table(tm[1])) continue;
 						}
-						system(pkg.ip_full + ' -4 rule del priority ' + prio + ' 2>/dev/null');
+						system(pkg.ip_full + ' -4 rule del priority ' + sh.quote(prio) + ' 2>/dev/null');
 					}
 				}
-				system(pkg.ip_full + ' -4 rule del lookup main suppress_prefixlength ' + cfg.prefixlength + ' 2>/dev/null');
+				system(pkg.ip_full + ' -4 rule del lookup main suppress_prefixlength ' + sh.quote(cfg.prefixlength) + ' 2>/dev/null');
 
 				let rules6 = sh.exec(pkg.ip_full + ' -6 rule show 2>/dev/null');
 				if (rules6) {
@@ -707,10 +707,10 @@ function create_nft(fs_mod, config, sh, output, pkg, platform, network, V, state
 							let tm = match(line, /lookup\s+(\S+)/);
 							if (tm && network.is_netifd_table(tm[1])) continue;
 						}
-						system(pkg.ip_full + ' -6 rule del priority ' + prio + ' 2>/dev/null');
+						system(pkg.ip_full + ' -6 rule del priority ' + sh.quote(prio) + ' 2>/dev/null');
 					}
 				}
-				system(pkg.ip_full + ' -6 rule del lookup main suppress_prefixlength ' + cfg.prefixlength + ' 2>/dev/null');
+				system(pkg.ip_full + ' -6 rule del lookup main suppress_prefixlength ' + sh.quote(cfg.prefixlength) + ' 2>/dev/null');
 				break;
 			}
 			case 'main_chains': {

--- a/files/lib/pbr/output.uc
+++ b/files/lib/pbr/output.uc
@@ -31,8 +31,15 @@ function create_output(sh, pkg_name, sym) {
 			let clean = replace(msg, /\x1b\[[0-9;]*m/g, '');
 			clean = replace(clean, /\\n/g, '\n');
 			clean = trim(clean);
+			// Argument ARRAY, not a shell string: the message reaches logger as
+			// one argv element, so arbitrary log text -- interface names, UCI
+			// values, nft error output -- can never be re-split on spaces or
+			// read as shell syntax. This is why sh.quote() is gone from here,
+			// and why `sh` is now unused by create_output(). system() has taken
+			// arrays since well before the oldest ucode pbr supports; see
+			// create_sys().ip() in sys.uc for the full rationale.
 			if (clean != '')
-				system('/usr/bin/logger -t ' + sh.quote(script_name) + ' ' + sh.quote(clean));
+				system(['/usr/bin/logger', '-t', script_name, clean]);
 		} else {
 			output_queue += msg;
 		}
@@ -40,7 +47,7 @@ function create_output(sh, pkg_name, sym) {
 
 	function logger_debug(debug_performance, msg) {
 		if (debug_performance)
-			system('/usr/bin/logger -t ' + sh.quote(script_name) + ' ' + sh.quote(msg));
+			system(['/usr/bin/logger', '-t', script_name, msg]);
 	}
 
 	let out = {

--- a/files/lib/pbr/pbr.uc
+++ b/files/lib/pbr/pbr.uc
@@ -1236,10 +1236,10 @@ function create_pbr(fs_mod, uci_mod, ubus_mod) {
 							return;
 						}
 						let tbl = pkg.ip_table_prefix + '_' + cfg.uplink_interface4;
-						system(pkg.ip_full + ' -4 rule del sport ' + listen_port + ' table ' + tbl + ' priority ' + prio + ' 2>/dev/null');
+						system(pkg.ip_full + ' -4 rule del sport ' + sh.quote(listen_port) + ' table ' + sh.quote(tbl) + ' priority ' + sh.quote(prio) + ' 2>/dev/null');
 						sh.ip('-4', 'rule', 'add', 'sport', listen_port, 'table', tbl, 'priority', prio);
 						if (cfg.ipv6_enabled) {
-							system(pkg.ip_full + ' -6 rule del sport ' + listen_port + ' table ' + tbl + ' priority ' + prio + ' 2>/dev/null');
+							system(pkg.ip_full + ' -6 rule del sport ' + sh.quote(listen_port) + ' table ' + sh.quote(tbl) + ' priority ' + sh.quote(prio) + ' 2>/dev/null');
 							sh.ip('-6', 'rule', 'add', 'sport', listen_port, 'table', tbl, 'priority', prio);
 						}
 						prio = '' + (+prio - 1);
@@ -1258,13 +1258,13 @@ function create_pbr(fs_mod, uci_mod, ubus_mod) {
 			iface_priority = prio;
 			return 0;
 		}
-		system(pkg.ip_full + ' -4 rule del priority ' + prio + ' 2>/dev/null');
-		system(pkg.ip_full + ' -4 rule del lookup main suppress_prefixlength ' + cfg.prefixlength + ' 2>/dev/null');
+		system(pkg.ip_full + ' -4 rule del priority ' + sh.quote(prio) + ' 2>/dev/null');
+		system(pkg.ip_full + ' -4 rule del lookup main suppress_prefixlength ' + sh.quote(cfg.prefixlength) + ' 2>/dev/null');
 		sh.try_cmd(state.errors, pkg.ip_full, '-4', 'rule', 'add', 'lookup', 'main', 'suppress_prefixlength',
 			'' + cfg.prefixlength, 'pref', prio);
 		if (cfg.ipv6_enabled) {
-			system(pkg.ip_full + ' -6 rule del priority ' + prio + ' 2>/dev/null');
-			system(pkg.ip_full + ' -6 rule del lookup main suppress_prefixlength ' + cfg.prefixlength + ' 2>/dev/null');
+			system(pkg.ip_full + ' -6 rule del priority ' + sh.quote(prio) + ' 2>/dev/null');
+			system(pkg.ip_full + ' -6 rule del lookup main suppress_prefixlength ' + sh.quote(cfg.prefixlength) + ' 2>/dev/null');
 			sh.try_cmd(state.errors, pkg.ip_full, '-6', 'rule', 'add', 'lookup', 'main', 'suppress_prefixlength',
 				'' + cfg.prefixlength, 'pref', prio);
 		}

--- a/files/lib/pbr/sys.uc
+++ b/files/lib/pbr/sys.uc
@@ -43,6 +43,12 @@ function create_sys(fs_mod, pkg) {
 		return false;
 	}
 
+	// Callers pass an argument VECTOR. Hand it to system() as an array so it is
+	// execvp()'d directly: no shell, so no quoting, no re-splitting on spaces,
+	// and no metacharacter interpretation of UCI-derived values. system() has
+	// accepted arrays since long before the oldest ucode pbr supports
+	// (verified on ucode 85922056 / OpenWrt 25.12) -- unlike fs.popen(), which
+	// is string-only there. Non-string elements are coerced by system() itself.
 	function ip(...args) {
 		if (length(args) < 1) return 1;
 		let fam = args[0];
@@ -62,14 +68,17 @@ function create_sys(fs_mod, pkg) {
 					push(newargs, rule_args[i]);
 				}
 				if (prio != null) {
-					system(pkg.ip_full + ' ' + fam + ' rule del priority ' + prio + ' 2>/dev/null');
-					return system(pkg.ip_full + ' ' + fam + ' rule add ' + join(' ', newargs) + ' pref ' + prio);
+					// Keeps the shell: system() has no fd redirection, and this
+					// delete is expected to fail when no such rule exists, so
+					// its stderr must be suppressed. quote() the interpolation.
+					system(pkg.ip_full + ' ' + fam + ' rule del priority ' + quote(prio) + ' 2>/dev/null');
+					return system([pkg.ip_full, fam, 'rule', 'add', ...newargs, 'pref', prio]);
 				}
-				return system(pkg.ip_full + ' ' + fam + ' rule add ' + join(' ', newargs));
+				return system([pkg.ip_full, fam, 'rule', 'add', ...newargs]);
 			}
-			return system(pkg.ip_full + ' ' + fam + ' ' + join(' ', rest));
+			return system([pkg.ip_full, fam, ...rest]);
 		}
-		return system(pkg.ip_full + ' ' + join(' ', args));
+		return system([pkg.ip_full, ...args]);
 	}
 
 	function try_cmd(errors, ...args) {

--- a/tests/01_validation/04_mocklib_system_recorder
+++ b/tests/01_validation/04_mocklib_system_recorder
@@ -64,7 +64,7 @@ push(checks,
 	// and the absence of one -- nothing is torn down live before that swap
 	['no_chain_flush',       length(flushes) == 0],
 	// the ip rule deletes go to system() directly
-	['rule_delete_recorded', mocklib.has_command('rule del priority 30000')],
+	['rule_delete_recorded', mocklib.has_command("rule del priority '30000'")],
 	['no_priority_zero_del', !mocklib.has_command(/rule del priority 0 /)]);
 
 let pass = 0, fail = 0;

--- a/tests/01_validation/05_sh_ip_argv
+++ b/tests/01_validation/05_sh_ip_argv
@@ -1,0 +1,77 @@
+sh.ip() hands system() an argument VECTOR rather than a joined string, so the
+command is execvp()'d directly with no shell in between. This pins the two
+things that buys: an argument containing a space stays ONE argv element instead
+of being re-split, and shell metacharacters in UCI-derived values are inert.
+
+mocklib.commands() cannot see either property -- it flattens an array call with
+join(' '), so ['a b','c'] and ['a','b','c'] record identically. The assertions
+below therefore read mocklib.argvs(), which keeps the array as an array.
+
+The one call that must NOT become an array is the `rule del ... 2>/dev/null`
+inside a rule replace: system() has no fd redirection, and that delete is
+expected to fail when the rule is absent, so its stderr has to be suppressed by
+a shell. It stays a string and gets quote()d instead -- asserted here so a later
+cleanup does not silently drop the redirect or the quoting.
+
+-- Testcase --
+import create_sys from 'sys';
+import pkgmod from 'pkg';
+
+let mocklib = global.mocklib;
+let pkg = pkgmod.pkg;
+let sh = create_sys(require('fs'), pkg);
+
+// ── an argument containing a space survives as one element ──────────
+mocklib.clear_commands();
+sh.ip('-4', 'rule', 'add', 'fwmark', '0x1000', 'table', 'my table');
+let a = mocklib.argvs()[0];
+
+// ── shell metacharacters are passed through, not interpreted ────────
+mocklib.clear_commands();
+sh.ip('-6', 'route', 'add', 'dev', 'a;touch /tmp/pbr_pwned');
+let b = mocklib.argvs()[0];
+
+// ── rule replace: the add is an array, the del stays a quoted string ─
+mocklib.clear_commands();
+sh.ip('-4', 'rule', 'replace', 'fwmark', '0x1000', 'priority', '30000');
+let calls = mocklib.argvs();
+
+// ── no-family form still passes a vector ────────────────────────────
+mocklib.clear_commands();
+sh.ip('route', 'flush', 'cache');
+let d = mocklib.argvs()[0];
+
+let checks = [
+	['space_arg_is_array',   type(a) == 'array'],
+	['space_arg_not_split',  length(a) == 8 && a[7] == 'my table'],
+	['space_arg_argv0',      a[0] == pkg.ip_full && a[1] == '-4'],
+	['metachar_one_element', type(b) == 'array' && length(b) == 6 &&
+	                         b[5] == 'a;touch /tmp/pbr_pwned'],
+	['replace_two_calls',    length(calls) == 2],
+	// the delete keeps its shell for 2>/dev/null, and quotes the priority
+	['del_is_string',        type(calls[0]) == 'string'],
+	['del_keeps_redirect',   index(calls[0], '2>/dev/null') >= 0],
+	['del_quotes_priority',  index(calls[0], "priority '30000'") >= 0],
+	// the add carries the vector, with pref appended after the filtered args
+	['add_is_array',         type(calls[1]) == 'array'],
+	['add_has_pref',         calls[1][length(calls[1]) - 2] == 'pref' &&
+	                         calls[1][length(calls[1]) - 1] == '30000'],
+	['add_drops_priority',   !('priority' in calls[1])],
+	['no_family_is_array',   type(d) == 'array' && d[0] == pkg.ip_full && d[1] == 'route'],
+];
+
+let pass = 0, fail = 0;
+for (let c in checks) {
+	if (c[1]) {
+		pass++;
+	} else {
+		fail++;
+		printf("FAIL: %s\n", c[0]);
+	}
+}
+printf("sh_ip_argv: %d/%d passed\n", pass, pass + fail);
+-- End --
+
+-- Expect stdout --
+sh_ip_argv: 12/12 passed
+-- End --

--- a/tests/02_config/08_prefixlength_validated
+++ b/tests/02_config/08_prefixlength_validated
@@ -1,0 +1,69 @@
+suppress_prefixlength is interpolated into an `ip rule` command line, but UCI
+declares it a plain string with no bound, so whatever is in /etc/config/pbr
+reached the shell verbatim. This pins the normalisation added in config.uc:
+anything that is not a run of digits falls back to the default '1', and values
+above the 128-bit protocol maximum are clamped.
+
+The fixture sets a value carrying a shell metacharacter. Two things must hold
+afterwards: cfg.prefixlength is the sanitised '1', and the `ip rule del` command
+built from it -- which keeps a shell for its 2>/dev/null -- contains no trailing
+injected command.
+
+-- Testcase --
+import create_pbr from 'pbr';
+
+let mocklib = global.mocklib;
+let pbr = create_pbr();
+
+// start_service() is what turns cfg.prefixlength into an `ip rule` invocation
+mocklib.clear_commands();
+pbr.start_service(['on_start']);
+
+let dels = mocklib.commands('suppress_prefixlength');
+let injected = mocklib.commands(/touch \/tmp\/pbr_pwned/);
+
+let checks = [
+	['suppress_rule_issued',  length(dels) >= 1],
+	// the metacharacter payload never reaches a command line
+	['no_injected_command',   length(injected) == 0],
+	// and the value used is the sanitised default, quoted
+	['uses_sanitised_value',  mocklib.has_command("suppress_prefixlength '1'")],
+];
+
+let pass = 0, fail = 0;
+for (let c in checks) {
+	if (c[1]) {
+		pass++;
+	} else {
+		fail++;
+		printf("FAIL: %s\n", c[0]);
+	}
+}
+printf("prefixlength_validated: %d/%d passed\n", pass, pass + fail);
+-- End --
+
+-- File uci/pbr.json --
+{
+	"pbr": [
+		{
+			".name": "config",
+			"enabled": "1",
+			"fw_mask": "00ff0000",
+			"ipv6_enabled": "0",
+			"prefixlength": "1; touch /tmp/pbr_pwned",
+			"strict_enforcement": "1",
+			"uplink_interface": "wan",
+			"uplink_interface6": "wan6",
+			"uplink_ip_rules_priority": "30000",
+			"uplink_mark": "00010000",
+			"verbosity": "2",
+			"lan_device": ["br-lan"],
+			"resolver_instance": ["*"]
+		}
+	]
+}
+-- End --
+
+-- Expect stdout --
+prefixlength_validated: 3/3 passed
+-- End --

--- a/tests/03_nft_rules/06_prio_min_floor
+++ b/tests/03_nft_rules/06_prio_min_floor
@@ -75,19 +75,19 @@ let deletes = mocklib.commands(/rule del priority /);
 
 let checks = [
 	// the guard itself -- both families, both loops
-	['no_v4_priority_zero',   !mocklib.has_command('-4 rule del priority 0 ')],
-	['no_v6_priority_zero',   !mocklib.has_command('-6 rule del priority 0 ')],
-	['no_negative_priority',  !mocklib.has_command(/rule del priority -/)],
+	['no_v4_priority_zero',   !mocklib.has_command("-4 rule del priority '0'")],
+	['no_v6_priority_zero',   !mocklib.has_command("-6 rule del priority '0'")],
+	['no_negative_priority',  !mocklib.has_command(/rule del priority '?-/)],
 	// the window still does its job, or the checks above would pass vacuously
-	['v4_in_window_deleted',   mocklib.has_command('-4 rule del priority 99 ')],
-	['v6_in_window_deleted',   mocklib.has_command('-6 rule del priority 99 ')],
-	['v4_prio_max_deleted',    mocklib.has_command('-4 rule del priority 100 ')],
+	['v4_in_window_deleted',   mocklib.has_command("-4 rule del priority '99'")],
+	['v6_in_window_deleted',   mocklib.has_command("-6 rule del priority '99'")],
+	['v4_prio_max_deleted',    mocklib.has_command("-4 rule del priority '100'")],
 	// and stays inside its bounds at the top end
-	['above_window_kept',     !mocklib.has_command('rule del priority 32766')],
-	['default_rule_kept',     !mocklib.has_command('rule del priority 32767')],
+	['above_window_kept',     !mocklib.has_command("rule del priority '32766'")],
+	['default_rule_kept',     !mocklib.has_command("rule del priority '32767'")],
 	// the unconditional suppress_prefixlength deletes are unaffected
-	['v4_suppress_deleted',    mocklib.has_command('-4 rule del lookup main suppress_prefixlength 1')],
-	['v6_suppress_deleted',    mocklib.has_command('-6 rule del lookup main suppress_prefixlength 1')],
+	['v4_suppress_deleted',    mocklib.has_command("-4 rule del lookup main suppress_prefixlength '1'")],
+	['v6_suppress_deleted',    mocklib.has_command("-6 rule del lookup main suppress_prefixlength '1'")],
 	// the invariant behind all of the above, over every delete pbr issues --
 	// the cleanup window and the per-interface deletes alike
 	['all_priorities_positive',

--- a/tests/03_nft_rules/07_mwan4_chains_survive_stop
+++ b/tests/03_nft_rules/07_mwan4_chains_survive_stop
@@ -84,12 +84,12 @@ let checks = [
 	['fw4_reloaded',        mocklib.has_command('fw4 -q reload')],
 	['route_cache_flushed', mocklib.has_command('route flush cache')],
 	['rt_tables_synced',    mocklib.has_command('sync')],
-	['pbr_rules_removed',   mocklib.has_command('-4 rule del priority 29999')],
+	['pbr_rules_removed',   mocklib.has_command("-4 rule del priority '29999'")],
 	// the promise: nothing pbr does on stop goes near mwan4 -- not its chains,
 	// and not the ip rules it parks well below pbr's cleanup window either
 	['mwan4_untouched',     !mocklib.has_command('mwan4')],
-	['mwan4_ip_rule_kept',  !mocklib.has_command('rule del priority 2001')],
-	['kernel_local_kept',   !mocklib.has_command('rule del priority 0 ')],
+	['mwan4_ip_rule_kept',  !mocklib.has_command("rule del priority '2001'")],
+	['kernel_local_kept',   !mocklib.has_command("rule del priority '0'")],
 	['no_foreign_chain_op', length(foreign_chain_ops) == 0],
 	// fw4's own chains are not pbr's to tear down either
 	['fw4_base_chains_kept',

--- a/tests/05_interfaces/04_uplink_down_no_failed_to_start
+++ b/tests/05_interfaces/04_uplink_down_no_failed_to_start
@@ -46,11 +46,14 @@ let pbr = create_pbr();
 
 // Capture every system() call so we can scan for the FAILED-TO-START
 // logger invocation. mocklib already stubs system to return 0; we wrap
-// it to also record the command string.
+// it to also record the command. system() takes either a string or an
+// argument array -- output.uc passes the logger call as an array so no
+// shell sees the message -- so flatten to a string the way mocklib's
+// own commands() recorder does, and scan that.
 let system_calls = [];
 let _prev_system = global.system;
 global.system = function(argv, timeout) {
-	push(system_calls, argv);
+	push(system_calls, type(argv) == 'array' ? join(' ', argv) : '' + argv);
 	return _prev_system(argv, timeout);
 };
 
@@ -63,11 +66,11 @@ let pbr2 = create_pbr();
 pbr2.service_started('on_start', result?.deferredToBoot ? '1' : '');
 
 let failed_to_start = filter(system_calls,
-	c => type(c) == 'string' && index(c, 'FAILED TO START') >= 0);
+	c => index(c, 'FAILED TO START') >= 0);
 let check_output = filter(system_calls,
-	c => type(c) == 'string' && index(c, 'Check the output of nft -c -f') >= 0);
+	c => index(c, 'Check the output of nft -c -f') >= 0);
 let uplink_warn = filter(system_calls,
-	c => type(c) == 'string' && index(c, 'Uplink/WAN interface is still down') >= 0);
+	c => index(c, 'Uplink/WAN interface is still down') >= 0);
 
 let checks = [
 	['start_service_returns_partial', type(result) == 'object'],

--- a/tests/lib/mocklib.uc
+++ b/tests/lib/mocklib.uc
@@ -169,6 +169,7 @@ let _captured = {};
    each and cannot leak into the next; clear_commands() is for asserting a single
    phase within one run, not for cleaning up after another test. */
 let _commands = [];
+let _argvs = [];
 
 /* Select recorded commands: everything when needle is null, those containing
    needle when it is a string, those matching it when it is a regexp. */
@@ -265,7 +266,14 @@ global.mocklib = {
 
 	/* Drop everything recorded so far, so a test can record one phase at a
 	   time (e.g. clear after start_service() to assert on stop_service()) */
-	clear_commands: () => { _commands = []; },
+	clear_commands: () => { _commands = []; _argvs = []; },
+
+	/* Read what system() was called with WITHOUT the join(' ') flattening that
+	   commands() applies -- an array call is returned as an array. Needed to
+	   assert that an argument containing a space is passed as ONE argv element
+	   rather than being re-split by a shell; commands() cannot see that
+	   difference, since ['a b','c'] and ['a','b','c'] join identically. */
+	argvs: () => [ ..._argvs ],
 };
 
 /* Override stdlib functions */
@@ -276,6 +284,7 @@ global.system = function(argv, timeout) {
 	   including the '[ -t 2 ]' tty probe below, so the list reflects the
 	   process exactly as it ran. */
 	push(_commands, type(argv) == "array" ? join(' ', argv) : '' + argv);
+	push(_argvs, type(argv) == "array" ? [ ...argv ] : '' + argv);
 
 	/* Return 1 for tty checks so output goes to logger, not stderr */
 	if (type(argv) == "string" && index(argv, "[ -t ") >= 0)


### PR DESCRIPTION
sh.ip() received an argument vector from all 12 try_ip callers, flattened it with join(' '), and handed the result to system() as a string -- so /bin/sh re-split it on whitespace. Any argument containing a space was silently wrong, and UCI-derived values reached the shell as text.

system() has accepted an array since long before the oldest ucode pbr supports (uc_system()'s UC_ARRAY branch is present in 85922056 / OpenWrt 25.12), where it is execvp()'d with no shell involved. Verified on the DL-WRX36 running ucode-2026.01.16~85922056 and on an x86 master build running ucode-2026.07.09~b885dd0f. This is unlike fs.popen(), which is string-only on both and stays as it is.

Ten system() calls must keep a shell: they need 2>/dev/null to suppress the expected failure of deleting an absent rule, and system() offers no fd redirection. Those get sh.quote() on every interpolated value instead.

Also normalise cfg.prefixlength. UCI declares it a plain string with no bound, so /etc/config/pbr content reached an ip rule command line verbatim; clamp it the way uplink_ip_rules_priority already is. listen_port, read from /etc/config/network, is covered by the quoting above.

Both sources are root-owned config, so this is robustness rather than a privilege boundary -- but a space or a quote in the wrong UCI field produced a failure far from its cause.

mocklib gains argvs(). commands() flattens an array call with join(' '), so ['a b','c'] and ['a','b','c'] record identically and it structurally cannot see the defect being fixed. Four existing tests are updated for the now-quoted command text; 04_uplink_down_no_failed_to_start rolled its own system() capture that assumed strings and dropped the array-form logger call.

Tests: 59/59. Both new tests confirmed to fail when their fix is reverted.
check-ucode-syntax.sh against the router's own 85922056 build: 17 files, 0 failed.