### PR TITLE
pbr-1.2.3: remove only pbr's own entry from dnsmasq's addnmount list

### DIFF
--- a/files/lib/pbr/nft.uc
+++ b/files/lib/pbr/nft.uc
@@ -848,12 +848,16 @@ function create_nft(fs_mod, config, sh, output, pkg, platform, network, V, state
 		if (!ctx.get('dhcp', instance)) return false;
 		let confdir = resolver._dnsmasq_get_confdir(instance);
 		if (confdir) unlink(confdir + '/' + pkg.name);
+		// Drop ONLY our own entry. uci.delete() takes three arguments
+		// (config, section, option) -- a fourth is silently ignored, so
+		// delete(..., 'addnmount', file) wipes the whole list, taking every
+		// other package's mount (adblock's, most visibly) with it, and their
+		// directories stop being mounted into dnsmasq's jail on its next
+		// start. list_remove() is the call that removes a single value.
 		let current = ctx.get('dhcp', instance, 'addnmount');
 		if (type(current) == 'array') {
-			let idx = index(current, pkg.dnsmasq_file);
-			if (idx >= 0) {
-				ctx.reorder('dhcp', instance, idx);
-				ctx.delete('dhcp', instance, 'addnmount', pkg.dnsmasq_file);
+			if (index(current, pkg.dnsmasq_file) >= 0) {
+				ctx.list_remove('dhcp', instance, 'addnmount', pkg.dnsmasq_file);
 				ctx.save('dhcp');
 			}
 		}

--- a/tests/03_nft_rules/12_dnsmasq_addnmount_kept
+++ b/tests/03_nft_rules/12_dnsmasq_addnmount_kept
@@ -1,0 +1,110 @@
+Testing that dnsmasq cleanup removes only pbr's own addnmount entry.
+
+dnsmasq runs jailed, and every directory it must see inside that jail is listed
+as an `addnmount` on its uci section -- pbr's /var/run/pbr.dnsmasq, adblock's
+/tmp/adblock-backup, and whatever else a package added. The list is shared state.
+
+uci.delete() takes three arguments (config, section, option); a fourth is
+accepted by the call and silently ignored. Cleanup passed the value as a fourth
+argument, so instead of dropping pbr's entry it dropped the entire addnmount
+option, and dnsmasq's next start came up with adblock's directory unmounted --
+reported as an adblock regression, and "fixed" until the next pbr restart by
+reloading adblock, which re-adds its own entry.
+
+list_remove() is the call that removes one value. The section itself must not be
+reordered either: the old code called reorder() with the value's list index,
+which shuffles the dnsmasq section within /etc/config/dhcp for no reason.
+
+-- Testcase --
+import create_nft from 'nft';
+
+let PBR_FILE = '/var/run/pbr.dnsmasq';
+
+// A dnsmasq section carrying three packages' mounts, pbr's in the middle.
+let section = {
+	'.name': 'cfg01411c',
+	'.type': 'dnsmasq',
+	'.index': 0,
+	addnmount: [ '/tmp/adblock-backup', PBR_FILE, '/var/run/https-dns-proxy' ],
+};
+
+let reorders = [];
+
+// A cursor with the real ucode uci semantics, as measured on ucode 85922056:
+// delete() ignores anything past the option name and takes the whole option
+// with it, while list_remove() takes one value out of the list.
+let ctx = {
+	get: function(conf, sect, opt) {
+		if (sect != section['.name']) return null;
+		return opt ? section[opt] : section['.type'];
+	},
+	'delete': function(conf, sect, opt) {
+		if (opt) delete section[opt];
+	},
+	list_remove: function(conf, sect, opt, val) {
+		if (type(section[opt]) == 'array')
+			section[opt] = filter(section[opt], v => v != val);
+	},
+	reorder: function(conf, sect, idx) { push(reorders, [ sect, idx ]); },
+	foreach: function(conf, stype, cb) { cb({ ...section }); },
+	save: function() {},
+	commit: function() {},
+	changes: function() { return []; },
+};
+
+let fs_mod = {
+	readfile: function() { return null; },
+	writefile: function() { return 0; },
+	// /etc/config/dhcp exists; nothing else does.
+	stat: function(p) { return p == '/etc/config/dhcp' ? { type: 'file' } : null; },
+	unlink: function() {},
+	dirname: function() { return '.'; },
+	open: function() { return { write: function() { return 0; }, close: function() {} }; },
+};
+
+let config = {
+	cfg: { resolver_set: 'dnsmasq.nftset' },
+	uci_ctx: function() { return ctx; },
+	// No dnsmasq instance on ubus: _dnsmasq_get_confdir() gives up, which is
+	// not what this test is about.
+	ubus_call: function() { return null; },
+};
+let pkg      = { name: 'pbr', nft_table: 'fw4', nft_prefix: 'pbr', dnsmasq_file: PBR_FILE };
+let platform = { env: { resolver_set_supported: true } };
+let state    = { errors: [] };
+let sh       = { run: function() { return 0; }, exec: function() { return ''; }, quote: function(s) { return s; } };
+
+let nft = create_nft(fs_mod, config, sh, {}, pkg, platform, {}, {}, state);
+
+nft.resolver.cleanup();
+
+let mounts = section.addnmount;
+let checks = [];
+
+// The other packages' mounts survive -- this is the whole bug.
+push(checks, ['adblock_kept',   type(mounts) == 'array' && index(mounts, '/tmp/adblock-backup') >= 0]);
+push(checks, ['hdp_kept',       type(mounts) == 'array' && index(mounts, '/var/run/https-dns-proxy') >= 0]);
+// pbr's own entry is gone.
+push(checks, ['pbr_removed',    type(mounts) != 'array' || index(mounts, PBR_FILE) < 0]);
+// The option itself is still there, with the two remaining entries in order.
+push(checks, ['option_kept',    type(mounts) == 'array' && length(mounts) == 2]);
+push(checks, ['order_kept',     type(mounts) == 'array' && mounts[0] == '/tmp/adblock-backup']);
+// And the dnsmasq section was not shuffled around in /etc/config/dhcp.
+push(checks, ['no_reorder',     length(reorders) == 0]);
+
+let pass = 0, fail = 0;
+for (let c in checks) {
+	if (c[1]) {
+		pass++;
+	} else {
+		fail++;
+		printf("FAIL: %s\n", c[0]);
+	}
+}
+printf("dnsmasq_addnmount_kept: %d/%d passed\n", pass, pass + fail);
+
+-- End --
+
+-- Expect stdout --
+dnsmasq_addnmount_kept: 6/6 passed
+-- End --

--- a/tests/lib/mocklib/uci.uc
+++ b/tests/lib/mocklib/uci.uc
@@ -208,6 +208,32 @@ return {
 			push(this._changes[config], { op: 'list_append', section, option, value });
 		},
 
+		/* Remove a single value from a list option, leaving the rest of the
+		   list intact -- the counterpart of list_append(), and what real uci
+		   does for `del_list`.
+
+		   Two fidelity details, both measured against ucode 85922056 rather
+		   than assumed: delete() above deliberately ignores a fourth
+		   argument, exactly as the C implementation does, so a test that
+		   passes one still sees the whole option disappear; and list_remove()
+		   does nothing at all to an option holding a plain string rather than
+		   a list, returning true and leaving the value in place. */
+		list_remove: function(config, section, option, value) {
+			if (!exists(this._configs, config))
+				this.load(config);
+
+			let sobj = this._get_section(config, section);
+			if (!sobj) return;
+
+			let current = sobj[option];
+			if (type(current) == 'array')
+				sobj[option] = filter(current, v => v != value);
+
+			if (!this._changes[config])
+				this._changes[config] = [];
+			push(this._changes[config], { op: 'list_remove', section, option, value });
+		},
+
 		save: function(config) {
 			/* No-op in mock: changes are already in memory */
 		},


### PR DESCRIPTION
resolver._dnsmasq_instance_cleanup() runs on every pbr stop and restart, and
called ctx.delete('dhcp', instance, 'addnmount', pkg.dnsmasq_file). ucode's
uci.delete() is delete(config, section[, option]): uc_uci_delete() reads three
arguments and a fourth is silently ignored, so with ptr.option already set
libuci deleted the entire option -- every other package's mount with it -- and
still returned true. The shell implementation this was converted from used
uci_remove_list (uci del_list); the ucode port lost that. list_remove() is the
call that removes a single value, and it is present in the oldest ucode pbr
supports.

Measured on a DL-WRX36 running ucode-2026.01.16~85922056, against a scratch
config dir:

  before          : [ "/tmp/adblock-backup", "/var/run/pbr.dnsmasq", "/var/run/https-dns-proxy" ]
  delete() rv     : true
  after delete()  : null
  list_remove rv  : true
  after list_rm() : [ "/tmp/adblock-backup", "/var/run/https-dns-proxy" ]

The adjacent ctx.reorder('dhcp', instance, idx) is dropped too. reorder(config,
section, index) moves a section within the package, so pbr was shuffling the
dnsmasq section around /etc/config/dhcp using a list index that has nothing to
do with section order.

This is a hard DNS outage for anyone holding a second addnmount, not a
degradation. Confirmed end to end on the same router with adblock 4.5.7-r3 and
adb_dnsshift=1, where adblock's conf-dir entry is a symlink into
/tmp/adblock-backup: one pbr restart drops that mount, and dnsmasq cannot read
its own config.

  addnmount before: '/var/run/pbr.dnsmasq' '/tmp/adblock-backup'
  addnmount after : '/var/run/pbr.dnsmasq'
  daemon.crit dnsmasq[1]: cannot access /tmp/dnsmasq.cfg01411c.d/adb_list.overall: No such file or directory
  daemon.crit dnsmasq[1]: FAILED to start up          (procd respawn, every 5s)
  nslookup openwrt.org 127.0.0.1 -> connection timed out; no servers could be reached

Reloading adblock re-adds its addnmount, which is why that appears to fix it --
until the next pbr restart. pbr's configure() re-adds pbr's own entry, so pbr
itself keeps working and only the other package's directory goes missing.

Exposure is narrower than it looks: adblock adds an addnmount only when
adb_dnsshift=1 (default 0, adblock.sh:37); with shift off it writes the list
straight into dnsmasq's conf-dir, which procd already mounts, and f_extconf()
actively del_lists the entry. The victims are shift=1 users and anything else
holding a second addnmount.

With the fix deployed on that router, four consecutive pbr restarts kept
adblock's entry and both jail mounts, with no duplicates and no dnsmasq
failures. pbr's own entry moves to the end of the list each cycle -- removed,
then re-appended -- which dnsmasq does not care about.

list_remove() is section-scoped exactly as delete() was, verified with two
dnsmasq sections and both addressing forms pbr uses ('guest' and '@dnsmasq[1]').
Worth noting the old behaviour was worse with several instances: configure()
cleans every instance before setting up the ones resolver_instance names, so
naming one instance stripped the list off the instances pbr was told to leave
alone, and those never got anything re-added.

mocklib's uci cursor gains list_remove(). It is array-only, and delete() keeps
ignoring a fourth argument, both matching the C implementation -- otherwise a
mock more helpful than libuci would hide this class of defect. A plain-string
option is left untouched by list_remove(), which also returns true.

Tests: 60/60. The new test is confirmed to fail 5 of its 6 checks when the fix
is reverted. check-ucode-syntax.sh against the router's own 85922056 build:
17 files, 0 failed.
