### PR TITLE
pbr-1.2.3: bump PKG_RELEASE from 91 to 93

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=pbr
 PKG_VERSION:=1.2.3
-PKG_RELEASE:=91
+PKG_RELEASE:=93
 PKG_LICENSE:=AGPL-3.0-or-later
 PKG_MAINTAINER:=Stan Grishin <stangri@melmac.ca>, Erik Conijn <egc112@msn.com>
 


### PR DESCRIPTION
Lockstep release bump with `luci-app-pbr`. Covers three fixes (#164, #167, #168) and one CI change (#163).

### pbr no longer removes other packages' entries from dnsmasq's `addnmount` list (#168)

Every stop and restart deleted the whole option rather than pbr's own line, so any entry another package had put there was lost. pbr re-adds its own on the way back up, so pbr itself kept working and only the other package's directory went missing from dnsmasq's jail.

With adblock configured for DNS shifting (`adb_dnsshift=1`) its blocklist lives behind that mount, and dnsmasq then refused to start at all:

```
daemon.crit dnsmasq[1]: cannot access /tmp/dnsmasq.cfg01411c.d/adb_list.overall: No such file or directory
daemon.crit dnsmasq[1]: FAILED to start up
```

— leaving the router with no DNS until adblock was reloaded. Reloading adblock looked like a fix, but only until the next pbr restart. Users of adblock **without** DNS shifting, which is the default, were not affected.

### The DNS prefetch helper runs again (#164)

`pbr.user.dnsprefetch` had been a silent no-op since the ucode rewrite — pbr logged it as run while it exited at its first check — and its trigger deadlocked against pbr's own progress, so enabling it made `/etc/init.d/pbr reload` take about 62 seconds instead of 2.

### Settings containing spaces or quotes are handled properly (#167)

Values from the configuration now reach `ip(2)` as an argument vector instead of being flattened into a shell command line, so an unusual character in a setting can no longer produce a failure far from its cause. `prefixlength` is clamped the way `uplink_ip_rules_priority` already was.

### Under the hood (#163)

CI now compiles every `.uc` file with the oldest ucode pbr supports — the revision OpenWrt 25.12 ships — so a construct only newer ucode accepts cannot reach a release.

---

Upgrading is enough; no manual cleanup. If a pbr restart has already stripped another package's `addnmount` entry, reloading that package restores it, and after this release it stays.

Compat is unchanged at 36 — no message catalog change in this cycle — so neither package warns about a version mismatch, but they are released together as usual.

Paired with mossdef-org/luci-app-pbr#46.
