### PR TITLE
pbr-1.2.3: keep a policy name from breaking the whole nft ruleset

### DIFF
--- a/files/lib/pbr/pbr.uc
+++ b/files/lib/pbr/pbr.uc
@@ -636,6 +636,12 @@ function create_pbr(fs_mod, uci_mod, ubus_mod) {
 	
 	function dns_policy_process(uid, enabled, name, src_addr, dest_dns, dest_dns_port) {
 		if (enabled != '1') return 0;
+		// The name reaches nft raw -- as the comment on every rule the policy
+		// emits, on the sets it creates, and as the trailing comment on
+		// dnsmasq's nftset lines. Sanitise it here, where it enters, rather
+		// than at each of the dozen interpolations downstream; the errors and
+		// log lines below then quote exactly what ends up in the ruleset.
+		name = V.nft_comment(name);
 	
 		src_addr = replace(src_addr, /[,;{};]/g, ' ');
 		dest_dns = replace(dest_dns, /[,;{}]/g, ' ');
@@ -706,6 +712,12 @@ function create_pbr(fs_mod, uci_mod, ubus_mod) {
 	
 	function policy_process(uid, enabled, name, interface_name, src_addr, src_port, dest_addr, dest_port, proto, chain) {
 		if (enabled != '1') return 0;
+		// The name reaches nft raw -- as the comment on every rule the policy
+		// emits, on the sets it creates, and as the trailing comment on
+		// dnsmasq's nftset lines. Sanitise it here, where it enters, rather
+		// than at each of the dozen interpolations downstream; the errors and
+		// log lines below then quote exactly what ends up in the ruleset.
+		name = V.nft_comment(name);
 	
 		src_addr = replace(src_addr, /[,;{};]/g, ' ');
 		src_port = replace(src_port, /[,;{}]/g, ' ');

--- a/files/lib/pbr/validators.uc
+++ b/files/lib/pbr/validators.uc
@@ -79,6 +79,35 @@ function filter_options(opt, values) {
 	return join(' ', ret);
 }
 
+// An nft comment is a double-quoted string with a hard 128-BYTE limit, and the
+// quote has no escape inside it: the first `"` ends the string and whatever
+// follows becomes syntax nft cannot parse. Both failures are caught by the
+// single `nft -c -f` in nft_file.apply(), which validates the WHOLE generated
+// file, so one policy whose name carries a quote -- or simply runs long -- takes
+// down every rule pbr writes, not just its own.
+//
+// Verified against nftables 1.0.9: `'`, `;`, `\`, `{}`, `$` and even a literal
+// newline all parse; 128 bytes passes and 129 does not (the limit counts bytes,
+// so 65 two-byte characters already fail); a multi-byte sequence left incomplete
+// by the cut is accepted.
+function nft_comment(s) {
+	if (s == null) return '';
+	// The quote becomes an apostrophe rather than being dropped, so a name like
+	// `My "work" laptop` still reads the way its author wrote it. CR/LF/TAB
+	// become spaces because this same string is also written as a trailing
+	// `# comment` on a line of dnsmasq's nftset config, where an embedded
+	// newline would inject a config line of its own.
+	let clean = replace('' + s, /"/g, "'");
+	clean = replace(clean, /[\r\n\t]/g, ' ');
+	// A BYTE truncation, deliberately: ucode's length()/substr() count bytes and
+	// so does nft's limit, so the two agree. Do not "improve" this into a
+	// character-aware cut -- 64 two-byte characters would pass such a check at
+	// 128 characters while still handing nft 256 bytes, which is the very
+	// failure this guards against. A sequence left incomplete by the cut is
+	// accepted by nft (verified), so there is nothing to repair afterwards.
+	return (length(clean) > 128) ? substr(clean, 0, 128) : clean;
+}
+
 function inline_set(value) {
 	if (!value) return '';
 	let parts = split(trim('' + value), /\s+/);
@@ -105,6 +134,7 @@ return {
 	is_family_mismatch,
 	filter_options,
 	inline_set,
+	nft_comment,
 };
 
 }

--- a/tests/03_nft_rules/13_policy_name_breaks_ruleset
+++ b/tests/03_nft_rules/13_policy_name_breaks_ruleset
@@ -1,0 +1,161 @@
+Testing that a policy name cannot take down the whole ruleset.
+
+The name is interpolated raw into every nft comment the policy produces -- the
+rules, the sets, and the trailing comment on dnsmasq's nftset lines. An nft
+comment is a double-quoted string with no escape for the quote and a hard
+128-byte limit, and nft_file.apply() validates the generated file with a single
+`nft -c -f`. So a name holding a `"`, or one that simply runs long, is not a
+cosmetic problem in that one policy: nft rejects the file, pbr installs nothing,
+and ALL policy routing stops -- the same "one policy kills everything" class as
+the negated-domain bug in 11_negation_on_same_rule.
+
+Both failure modes are reachable from the WebUI, and the length one is the
+likelier of the two: nobody types a quote into a policy name by accident, but a
+descriptive name reaches 128 bytes easily.
+
+Verified against nftables 1.0.9 -- `'`, `;`, `\`, `{}` and a literal newline
+all parse, so only the quote and the length need handling. A newline still has
+to go, because the same string is written as a `# comment` on a line of
+dnsmasq's nftset config, where it would inject a config line of its own.
+
+-- Testcase --
+import create_pbr from 'pbr';
+let pbr = create_pbr();
+
+pbr.start_service(['on_start']);
+
+let nft_content = global.mocklib.read_captured('/var/run/pbr.nft');
+let dnsmasq = global.mocklib.read_captured('/var/run/pbr.dnsmasq') || '';
+let checks = [];
+
+if (nft_content) {
+	let lines = split(nft_content, '\n');
+
+	// Pull out every comment payload, plus whatever the line has left over
+	// after the closing quote. On an unsanitised name the leftover is the tail
+	// of the name itself -- which is exactly what nft chokes on.
+	let comments = [], leftovers = [];
+	for (let l in lines) {
+		let i = index(l, ' comment "');
+		if (i < 0) continue;
+		let rest = substr(l, i + 10);
+		let e = index(rest, '"');
+		push(comments, e < 0 ? rest : substr(rest, 0, e));
+		push(leftovers, e < 0 ? '' : substr(rest, e + 1));
+	}
+	push(checks, ['comments_found', length(comments) > 0]);
+
+	// Nothing may follow the closing quote but the statement's own tail.
+	// Note the literal space and tab: `\s` is not a character class inside a
+	// bracket expression in ucode's regex, only outside one.
+	let stray = filter(leftovers, t => !!match(t, /[^;} \t]/));
+	push(checks, ['no_text_after_closing_quote', length(stray) == 0]);
+
+	// nft counts bytes, not characters, and refuses at 129.
+	let too_long = filter(comments, c => length(c) > 128);
+	push(checks, ['no_comment_over_128_bytes', length(too_long) == 0]);
+
+	// The quote is folded to an apostrophe, which nft accepts, so the name
+	// still reads the way its author wrote it.
+	push(checks, ['quote_folded_to_apostrophe',
+		length(filter(comments, c => c == "Say 'hi' now")) > 0]);
+	push(checks, ['no_raw_quote_left', length(filter(comments, c => index(c, '"') >= 0)) == 0]);
+
+	// The long name is cut to the limit, not dropped: it still identifies its
+	// policy in `nft list ruleset`.
+	let cut = filter(comments, c => index(c, 'Route everything from the guest network over the backup upli') == 0);
+	push(checks, ['long_name_kept_and_cut', length(cut) > 0 && length(cut[0]) == 128]);
+
+	// A newline would have split the comment across two lines of the file.
+	push(checks, ['newline_folded_to_space',
+		length(filter(comments, c => c == 'Two line name')) > 0]);
+} else {
+	push(checks, ['nft_file_written', false]);
+}
+
+// The same string is a trailing comment in dnsmasq's config; a newline there
+// injects a directive dnsmasq then fails to parse.
+let dlines = filter(split(dnsmasq, '\n'), l => l != '');
+push(checks, ['dnsmasq_lines_written', length(dlines) > 0]);
+push(checks, ['every_dnsmasq_line_is_an_nftset',
+	length(filter(dlines, l => index(l, 'nftset=') != 0)) == 0]);
+
+let pass = 0, fail = 0;
+for (let c in checks) {
+	if (c[1]) {
+		pass++;
+	} else {
+		fail++;
+		printf("FAIL: %s\n", c[0]);
+	}
+}
+printf("policy_name_breaks_ruleset: %d/%d passed\n", pass, pass + fail);
+-- End --
+
+-- File fs/stat~_sys_class_net_br-lan.json --
+{ "type": "link" }
+-- End --
+
+-- File uci/pbr.json --
+{
+	"pbr": [
+		{
+			".name": "config",
+			"enabled": "1",
+			"fw_mask": "00ff0000",
+			"ipv6_enabled": "1",
+			"resolver_set": "dnsmasq.nftset",
+			"strict_enforcement": "1",
+			"uplink_interface": "wan",
+			"uplink_interface6": "wan6",
+			"uplink_ip_rules_priority": "30000",
+			"uplink_mark": "00010000",
+			"verbosity": "2",
+			"lan_device": ["br-lan"],
+			"resolver_instance": ["*"],
+			"debug_performance": "0",
+			"nft_set_auto_merge": "1",
+			"nft_set_flags_interval": "1",
+			"nft_set_flags_timeout": "0",
+			"nft_set_policy": "performance"
+		}
+	],
+	"policy": [
+		// A quote ends the nft comment string early; the rest of the name is
+		// then read as syntax.
+		{
+			".name": "policy_quote",
+			"name": "Say \"hi\" now",
+			"enabled": "1",
+			"interface": "wan",
+			"src_addr": "192.168.9.0/24",
+			"chain": "prerouting"
+		},
+		// Over the 128-byte limit. The domain destination puts the same name on
+		// a set and on a dnsmasq nftset line, so all three carriers are covered.
+		{
+			".name": "policy_long",
+			"name": "Route everything from the guest network over the backup uplink Route everything from the guest network over the backup uplink Route everything from the guest network over the backup uplink Route everything from the guest network over the backup uplink",
+			"enabled": "1",
+			"interface": "wan",
+			"src_addr": "192.168.10.0/24",
+			"dest_addr": "example.com",
+			"chain": "prerouting"
+		},
+		// Parses in nft, but injects a line into dnsmasq's config.
+		{
+			".name": "policy_newline",
+			"name": "Two\nline name",
+			"enabled": "1",
+			"interface": "wan",
+			"src_addr": "192.168.11.0/24",
+			"dest_addr": "other.example.com",
+			"chain": "prerouting"
+		}
+	]
+}
+-- End --
+
+-- Expect stdout --
+policy_name_breaks_ruleset: 9/9 passed
+-- End --


### PR DESCRIPTION
A policy name is interpolated raw into every nft comment the policy produces: the rules in `pbr.uc`, the sets in `nft.uc`, and the trailing `# comment` on dnsmasq's nftset lines. An nft comment is a double-quoted string with **no escape for the quote** and a hard **128-byte** limit, and `nft_file.apply()` validates the generated file with a single `nft -c -f`.

So a policy name is not a cosmetic field. One holding a `"`, or one that simply runs long, makes nft reject the file, pbr installs nothing, and **all** policy routing stops — the same "one policy kills everything" class as the negated-domain bug in #159. The symptom is `Installing fw4 nft file [x]`.

Both are reachable from the WebUI, and the length one is the likelier: nobody types a quote into a policy name by accident, but a descriptive name reaches 128 bytes easily.

## What nft actually accepts

Verified against nftables 1.0.9:

| in the name | result |
|---|---|
| `"` | `syntax error, unexpected string, expecting newline or semicolon` |
| >128 **bytes** | `Error: comment too long, 128 characters maximum allowed` |
| `'` `;` `\` `{}` `$`, literal newline | parse fine |
| incomplete UTF-8 sequence at the cut | accepted |

The limit counts bytes, not characters, so 65 two-byte characters (130 bytes) already fail while 64 pass — which is why the truncation is a byte truncation.

## The change

A new `V.nft_comment()` folds `"` to `'`, folds CR/LF/TAB to a space, and truncates to 128 bytes. The quote becomes an apostrophe rather than being dropped so `My "work" laptop` still reads the way its author wrote it.

It is applied once in `policy_process()` and `dns_policy_process()`, where the name enters, rather than at each of the dozen interpolations downstream. That covers all three carriers at once, and the error and log lines then quote exactly what ends up in the ruleset.

The newline is folded for a second reason: the same string is written as a trailing `# comment` on a line of dnsmasq's nftset config, where an embedded newline injects a config line of its own. That failure mode is not visible to nft at all.

## Testing

`tests/03_nft_rules/13_policy_name_breaks_ruleset`, three policies (a quote, a 251-byte name, an embedded newline), 9 checks. It scores **3/9 on the unfixed code**, so it is not vacuous.

Beyond the mocked assertions, the ruleset pbr actually generates for those three policies was fed to a real `nft -c -f`:

```
unfixed: Error: syntax error, unexpected string, expecting ... semicolon
         Error: comment too long, 128 characters maximum allowed   (x3)
fixed:   (no parse or comment errors)
```

- `Ran 61 tests, 61 okay, 0 failures`
- ucode syntax gate against the pinned `85922056` (OpenWrt 25.12) build: `checked 17 file(s), 0 failed`; the helper's runtime behaviour was also exercised on that interpreter, since byte-truncation and `replace()` semantics are what the fix rests on.
- No new message codes, so compat stays at 36.

## Not in this change

`config.uc` builds `_nft_set_params` with `gc_interval "<val>"` and `timeout "<val>"` from UCI. Chasing that turned up something worse than an escaping gap, so it is being handled as its own change rather than folded in here: the emitted syntax is invalid regardless of the value, because the shell version's `"$var"` quoting was carried into the ucode port as literal quotes in the nft text, `gc_interval` should be `gc-interval`, and the port also emits `timeout` twice. Any non-empty `nft_set_timeout` or `nft_set_gc_interval` therefore makes nft reject the whole file. Confirmed on nftables 1.1.6 on a 25.12 router. Defaults are empty, so a default install is unaffected.