### PR TITLE
pbr-1.2.3: emit nft set time values in a form nft accepts

### DIFF
--- a/files/lib/pbr/config.uc
+++ b/files/lib/pbr/config.uc
@@ -156,16 +156,32 @@ function create_config(uci_mod, ubus_mod, pkg) {
 		if (int(cfg.uplink_ip_rules_priority) < 99) cfg.uplink_ip_rules_priority = '99';
 		if (int(cfg.uplink_ip_rules_priority) > 32765) cfg.uplink_ip_rules_priority = '32765';
 
-		// Build nft_set_flags string
+		// An nft time value is a run of <decimal><unit>, unit being ms, s, m, h
+		// or d -- `1h`, `6h`, `1h30m`, `100ms`. A bare number is NOT accepted,
+		// and neither is a `w` for weeks; both were checked against nftables
+		// 1.0.9 and the 1.1.6 in OpenWrt 25.12. UCI declares these two options
+		// a free string with no bound, so a typo went straight into the set
+		// declaration. Drop a value nft cannot use rather than emit it: these
+		// are tuning knobs, and a whole ruleset nft refuses -- which stops ALL
+		// policy routing -- is a far worse outcome than an ignored timeout.
+		// Same treatment as prefixlength above.
+		if (cfg.nft_set_timeout && !match(cfg.nft_set_timeout, /^([0-9]+(ms|s|m|h|d))+$/))
+			cfg.nft_set_timeout = '';
+		if (cfg.nft_set_gc_interval && !match(cfg.nft_set_gc_interval, /^([0-9]+(ms|s|m|h|d))+$/))
+			cfg.nft_set_gc_interval = '';
+
+		// Build nft_set_flags string. Flags ONLY: the set's default timeout is
+		// emitted once, below. Appending it here as well put `timeout` in the
+		// declaration twice.
 		let nft_set_flags = '';
 		let fi = cfg.nft_set_flags_interval;
 		let ft = cfg.nft_set_flags_timeout;
 		if (fi && ft) {
-			nft_set_flags = 'flags interval, timeout' + (cfg.nft_set_timeout ? '; timeout ' + cfg.nft_set_timeout : '');
+			nft_set_flags = 'flags interval, timeout';
 		} else if (fi && !ft) {
 			nft_set_flags = 'flags interval';
 		} else if (!fi && ft) {
-			nft_set_flags = 'flags timeout' + (cfg.nft_set_timeout ? '; timeout ' + cfg.nft_set_timeout : '');
+			nft_set_flags = 'flags timeout';
 		}
 
 		if (!cfg.nft_set_flags_timeout && !cfg.nft_set_timeout) cfg.nft_set_gc_interval = '';
@@ -177,9 +193,15 @@ function create_config(uci_mod, ubus_mod, pkg) {
 		if (cfg.nft_set_auto_merge) push(set_parts, 'auto-merge;');
 		if (cfg.nft_set_counter) push(set_parts, 'counter;');
 		if (nft_set_flags) push(set_parts, nft_set_flags + ';');
-		if (cfg.nft_set_gc_interval) push(set_parts, 'gc_interval "' + cfg.nft_set_gc_interval + '";');
+		// `gc-interval`, not `gc_interval`, and both values go in BARE. The
+		// quotes here were the shell version's own -- `gc_interval "$val";` in
+		// the old init script, where the shell ate them before nft saw the
+		// line. The ucode port copied them in as literal characters, which nft
+		// rejects with `unexpected quoted string, expecting string`. `policy`
+		// was ported correctly and is left alone.
+		if (cfg.nft_set_gc_interval) push(set_parts, 'gc-interval ' + cfg.nft_set_gc_interval + ';');
 		if (cfg.nft_set_policy) push(set_parts, 'policy ' + cfg.nft_set_policy + ';');
-		if (cfg.nft_set_timeout) push(set_parts, 'timeout "' + cfg.nft_set_timeout + '";');
+		if (cfg.nft_set_timeout) push(set_parts, 'timeout ' + cfg.nft_set_timeout + ';');
 		cfg._nft_set_params = ' ' + join(' ', set_parts) + ' ';
 	}
 

--- a/tests/02_config/09_nft_set_time_values
+++ b/tests/02_config/09_nft_set_time_values
@@ -1,0 +1,115 @@
+nft's set declaration takes a time value as a bare run of <decimal><unit> --
+`1h`, `1h30m`, `100ms` -- with the unit one of ms, s, m, h, d. pbr got three
+things wrong about that, and each one on its own makes `nft -c -f` reject the
+generated file, which stops ALL policy routing rather than just ignoring the
+option:
+
+  * the values were emitted in double quotes. Those quotes belonged to the old
+    shell init script (`gc_interval "$nft_set_gc_interval";`), where the shell
+    consumed them; the ucode port copied them in as literal characters.
+  * `gc_interval` is not an nft keyword -- it is `gc-interval`. Wrong in the
+    shell version too, so that option had never worked.
+  * `timeout` was emitted twice: once folded into the flags string by the port,
+    once from set_parts.
+
+On top of that neither option was validated, so a typo like `1w` or `60` -- both
+rejected by nft -- reached the ruleset and killed it.
+
+Checked against nftables 1.0.9 and the 1.1.6 in OpenWrt 25.12: `1w` and bare
+numbers are refused by both, `100ms`, `0s`, `2d` and `1h30m` accepted by both.
+
+-- Testcase --
+import create_pbr from 'pbr';
+let pbr = create_pbr();
+
+pbr.start_service(['on_start']);
+
+let nft_content = global.mocklib.read_captured('/var/run/pbr.nft') || '';
+let sets = filter(split(nft_content, '\n'), l => index(l, 'add set ') == 0);
+let checks = [];
+
+push(checks, ['sets_emitted', length(sets) > 0]);
+
+// The declaration nft actually has to parse.
+let spec = length(sets) ? sets[0] : '';
+
+// Bare, not quoted. A quoted value is `unexpected quoted string`.
+push(checks, ['timeout_is_bare',    index(spec, 'timeout 1h30m;') >= 0]);
+push(checks, ['timeout_not_quoted', index(spec, 'timeout "') < 0]);
+
+// The keyword nft knows, spelled with a hyphen.
+push(checks, ['gc_interval_hyphenated', index(spec, 'gc-interval 5m;') >= 0]);
+push(checks, ['gc_interval_underscore_gone', index(spec, 'gc_interval') < 0]);
+
+// `timeout` may appear once as a FLAG and once as the set's default value,
+// and no more than that: the port used to emit the value twice.
+let flag_hits = 0, value_hits = 0;
+for (let part in split(spec, ';')) {
+	part = trim(part);
+	if (index(part, 'flags ') == 0) { if (index(part, 'timeout') >= 0) flag_hits++; }
+	else if (index(part, 'timeout ') == 0) value_hits++;
+}
+push(checks, ['timeout_flag_once',  flag_hits == 1]);
+push(checks, ['timeout_value_once', value_hits == 1]);
+
+// Every set pbr writes gets the same treatment, not just the first.
+push(checks, ['all_sets_consistent',
+	length(filter(sets, l => index(l, 'timeout "') >= 0 || index(l, 'gc_interval') >= 0)) == 0]);
+
+let pass = 0, fail = 0;
+for (let c in checks) {
+	if (c[1]) {
+		pass++;
+	} else {
+		fail++;
+		printf("FAIL: %s\n", c[0]);
+	}
+}
+printf("nft_set_time_values: %d/%d passed\n", pass, pass + fail);
+-- End --
+
+-- File fs/stat~_sys_class_net_br-lan.json --
+{ "type": "link" }
+-- End --
+
+-- File uci/pbr.json --
+{
+	"pbr": [
+		{
+			".name": "config",
+			"enabled": "1",
+			"fw_mask": "00ff0000",
+			"ipv6_enabled": "0",
+			"strict_enforcement": "1",
+			"uplink_interface": "wan",
+			"uplink_interface6": "",
+			"uplink_ip_rules_priority": "30000",
+			"uplink_mark": "00010000",
+			"verbosity": "2",
+			"lan_device": ["br-lan"],
+			"debug_performance": "0",
+			"nft_set_auto_merge": "1",
+			"nft_set_counter": "1",
+			"nft_set_flags_interval": "1",
+			"nft_set_flags_timeout": "1",
+			"nft_set_timeout": "1h30m",
+			"nft_set_gc_interval": "5m",
+			"nft_set_policy": "performance"
+		}
+	],
+	"policy": [
+		{
+			".name": "policy_a",
+			"name": "timeout probe",
+			"enabled": "1",
+			"interface": "wan",
+			"src_addr": "192.168.9.0/24",
+			"chain": "prerouting"
+		}
+	]
+}
+-- End --
+
+-- Expect stdout --
+nft_set_time_values: 8/8 passed
+-- End --

--- a/tests/02_config/10_nft_set_time_values_rejected
+++ b/tests/02_config/10_nft_set_time_values_rejected
@@ -1,0 +1,101 @@
+The companion to 09_nft_set_time_values: what happens to a value nft would
+refuse.
+
+UCI declares nft_set_timeout and nft_set_gc_interval free strings, so anything
+can be in them. `1w` looks reasonable and is rejected by nft (weeks are not a
+unit it knows); a bare `60` is rejected too. Emitting either one costs the user
+the WHOLE ruleset, not just the option, because nft_file.apply() validates the
+generated file in one `nft -c -f`.
+
+So an unusable value is dropped at load time instead. The set then carries no
+timeout, which is what pbr did before anyone touched these options -- a far
+better outcome than no policy routing at all. The same check incidentally closes
+the injection route these unquoted values would otherwise open.
+
+-- Testcase --
+import create_pbr from 'pbr';
+let pbr = create_pbr();
+
+pbr.start_service(['on_start']);
+
+let nft_content = global.mocklib.read_captured('/var/run/pbr.nft') || '';
+let sets = filter(split(nft_content, '\n'), l => index(l, 'add set ') == 0);
+let checks = [];
+
+push(checks, ['sets_emitted', length(sets) > 0]);
+
+// `1w` is not an nft time unit, so it must not reach the declaration.
+push(checks, ['bad_timeout_dropped',
+	length(filter(sets, l => index(l, 'timeout 1w') >= 0)) == 0]);
+
+// Nothing is left behind as a value-less `timeout ;` either.
+push(checks, ['no_empty_timeout',
+	length(filter(sets, l => index(l, 'timeout ;') >= 0)) == 0]);
+
+// The flags string is independent of the value and stays.
+push(checks, ['timeout_flag_kept',
+	length(filter(sets, l => index(l, 'flags interval, timeout;') >= 0)) == length(sets)]);
+
+// gc-interval carries a payload that would inject nft statements of its own.
+push(checks, ['bad_gc_interval_dropped',
+	length(filter(sets, l => index(l, 'gc-interval') >= 0)) == 0]);
+push(checks, ['no_injected_statement',
+	index(nft_content, 'pbr_pwned') < 0]);
+
+let pass = 0, fail = 0;
+for (let c in checks) {
+	if (c[1]) {
+		pass++;
+	} else {
+		fail++;
+		printf("FAIL: %s\n", c[0]);
+	}
+}
+printf("nft_set_time_values_rejected: %d/%d passed\n", pass, pass + fail);
+-- End --
+
+-- File fs/stat~_sys_class_net_br-lan.json --
+{ "type": "link" }
+-- End --
+
+-- File uci/pbr.json --
+{
+	"pbr": [
+		{
+			".name": "config",
+			"enabled": "1",
+			"fw_mask": "00ff0000",
+			"ipv6_enabled": "0",
+			"strict_enforcement": "1",
+			"uplink_interface": "wan",
+			"uplink_interface6": "",
+			"uplink_ip_rules_priority": "30000",
+			"uplink_mark": "00010000",
+			"verbosity": "2",
+			"lan_device": ["br-lan"],
+			"debug_performance": "0",
+			"nft_set_auto_merge": "1",
+			"nft_set_counter": "1",
+			"nft_set_flags_interval": "1",
+			"nft_set_flags_timeout": "1",
+			"nft_set_timeout": "1w",
+			"nft_set_gc_interval": "60; elements = { 1.2.3.4 } # pbr_pwned",
+			"nft_set_policy": "performance"
+		}
+	],
+	"policy": [
+		{
+			".name": "policy_a",
+			"name": "timeout probe",
+			"enabled": "1",
+			"interface": "wan",
+			"src_addr": "192.168.9.0/24",
+			"chain": "prerouting"
+		}
+	]
+}
+-- End --
+
+-- Expect stdout --
+nft_set_time_values_rejected: 6/6 passed
+-- End --


### PR DESCRIPTION
Any non-empty `nft_set_timeout` or `nft_set_gc_interval` made nft reject the generated file, so pbr installed nothing and **all** policy routing stopped. This is not an escaping gap — the syntax was invalid whatever the value was.

Found while writing the "not in this change" note on #170.

## Three defects, each fatal on its own

**The values were emitted in double quotes.** Those quotes were the old shell init script's own — `gc_interval "$nft_set_gc_interval";` — where the shell consumed them before nft ever saw the line. The ucode port copied them across as literal characters, and nft answers `unexpected quoted string, expecting string`. `policy` was ported correctly, which is why only these two lines change.

**`gc_interval` is not an nft keyword** — it is `gc-interval`. Wrong in the shell version too, so that option has never worked in any release, while pbr's own README documents it as `gc-interval`.

**`timeout` was emitted twice** — once folded into the flags string by the port, once from `set_parts`. The shell version's flags string was flags only.

Here is what r93 actually generates with `nft_set_flags_timeout=1`, `nft_set_timeout=6h`, `nft_set_gc_interval=5m`:

```
add set inet fw4 pbr_wan_4_dst_ip_cfg0d6ff5 { type ipv4_addr; auto-merge; counter;
  flags interval, timeout; timeout 6h; gc_interval "5m"; policy performance; timeout "6h";  comment "ipleak";}
```

## Validation

An nft time value is a run of `<decimal><unit>` with the unit one of `ms s m h d`. A bare number is rejected, and so is `w` for weeks. UCI declares both options free strings with no bound, so `1w` or `60` — neither unreasonable to type — reached the ruleset and killed it.

An unusable value is now dropped rather than emitted. These are tuning knobs; an ignored timeout beats no policy routing at all, and it is the same treatment `prefixlength` already gets in `load()`, so there is no new message code and compat is unchanged. The check also closes the injection route that unquoted values would otherwise open.

| value | nft 1.0.9 | nft 1.1.6 | validator |
|---|---|---|---|
| `1h`, `6h`, `1h30m`, `1h30m10s`, `2d`, `100ms`, `0s` | accepts | accepts | accepts |
| `1w`, `60`, `0`, `1.5h`, `1 h`, `-5m`, `abc` | rejects | rejects | rejects |

## Testing

`tests/02_config/09_nft_set_time_values` (8 checks, valid values) and `10_nft_set_time_values_rejected` (6 checks, `1w` plus an injection payload). They score **3/8 and 4/6 on the unfixed code**.

- `Ran 62 tests, 62 okay, 0 failures`
- ucode syntax gate against the pinned `85922056` (25.12) build: `checked 17 file(s), 0 failed`; the validator regex was also exercised on that interpreter value by value
- pbr's generated ruleset goes from rejected to accepted by a real `nft -c -f`

**On hardware** (x86 OpenWrt 25.12, nftables 1.1.6, pbr 1.2.3-r93, 90 policies). Stock r93 with `flags_timeout=1 / timeout=6h / gc_interval=5m` logs `pbr 1.2.3-r93 FAILED TO START!!!`. With this change the same config starts clean and the kernel reports:

```
set pbr_wan_4_dst_ip_cfg0d6ff5 {
        flags interval,timeout
        timeout 6h
        gc-interval 5m
        elements = { 3.173.21.63 ... expires 5h59m57s530ms, ... }
```

With `nft_set_timeout=1w` and an injection payload in `nft_set_gc_interval`, both are dropped, `flags interval, timeout;` is kept, the ruleset is accepted and no payload appears anywhere in the file.

## Two things found alongside, deliberately not fixed here

**Set attributes cannot change on a running system.** pbr's named sets survive `service pbr stop` — the include file is removed and all 32 `pbr_*` sets are still in `inet fw4` — so the next start emits an `add set` whose spec differs from the live one and the pre-check fails with `Error: Could not process rule: File exists`. Enabling these options therefore needs a `service firewall restart` (which does clear them) or a reboot; a plain `service pbr restart` can never apply them. This affects any set-attribute change, not just these options.

**An element's timeout is never refreshed.** Measured on a live domain set: after forcing a dnsmasq cache miss and a genuine re-add, `expires` keeps counting down from the original insertion. So `nft_set_timeout=6h` drops an address 6h after it first appeared however busy it is, and it only returns on the next lookup after that. Worth a docs note before this option is recommended for the "sets only grow" problem.