### PR TITLE
pbr-1.2.3: quote every argument sh.try_cmd() puts on a command line

### DIFF
--- a/files/lib/pbr/sys.uc
+++ b/files/lib/pbr/sys.uc
@@ -81,10 +81,17 @@ function create_sys(fs_mod, pkg) {
 		return system([pkg.ip_full, ...args]);
 	}
 
+	// Callers hand this an argument VECTOR too, but unlike ip() it cannot go to
+	// system() as an array: every caller is a command whose failure is expected
+	// and routine -- a route replace on an interface that has no gateway yet --
+	// so its stderr must be suppressed, and system() has no fd redirection (see
+	// run()). The shell therefore stays, and every element is quote()d instead,
+	// which is what keeps a value carrying a space or a shell metacharacter as
+	// one argv word. The recorded error carries the UNQUOTED join: that string
+	// is shown to the user, not executed.
 	function try_cmd(errors, ...args) {
-		let cmd = join(' ', args);
-		if (run(cmd) != 0) {
-			push(errors, { code: 'errorTryFailed', info: cmd });
+		if (run(join(' ', map(args, quote))) != 0) {
+			push(errors, { code: 'errorTryFailed', info: join(' ', args) });
 			return false;
 		}
 		return true;

--- a/tests/01_validation/06_sh_try_cmd_quoted
+++ b/tests/01_validation/06_sh_try_cmd_quoted
@@ -1,0 +1,115 @@
+sh.try_cmd() is the last place in sys.uc that builds a shell command line out
+of caller-supplied words. Unlike sh.ip(), it cannot hand system() an argument
+array: run() suppresses the command's output with `>/dev/null 2>&1`, system()
+has no fd redirection, and the suppression is not incidental -- every caller is
+an `ip route replace` whose failure is routine, on an interface that has no
+gateway yet.
+
+So the shell stays and each element is quote()d instead. That is the same rule
+#167 applied to the calls it could not convert: a value carrying a space stays
+one argv word, and a metacharacter in an interface or device name is inert.
+
+The error pushed onto state.errors keeps the UNQUOTED join -- it is shown to the
+user in `service pbr status`, not executed, and a line of shell quoting there
+would be noise.
+
+-- Testcase --
+import create_sys from 'sys';
+import pkgmod from 'pkg';
+
+let mocklib = global.mocklib;
+let pkg = pkgmod.pkg;
+let sh = create_sys(require('fs'), pkg);
+
+// mocklib's system() stub returns 0, so try_cmd takes the success path; the
+// failure path is exercised separately below by asking for a command that the
+// stub is told to fail.
+let errors = [];
+
+// ── a device name with a space stays one argv word ──────────────────
+mocklib.clear_commands();
+sh.try_cmd(errors, pkg.ip_full, '-4', 'route', 'replace', 'default',
+	'dev', 'my dev', 'table', '100');
+let a = mocklib.commands()[0] || '';
+
+// ── metacharacters are quoted, not interpreted ──────────────────────
+mocklib.clear_commands();
+sh.try_cmd(errors, pkg.ip_full, '-6', 'route', 'replace', 'default',
+	'dev', 'br0;touch /tmp/pbr_pwned', 'table', '100');
+let b = mocklib.commands()[0] || '';
+
+// ── a single quote in the value is escaped, not terminated ──────────
+// quote() wraps in single quotes and rewrites each ' as '\'' -- which only
+// holds if replace() with a string needle is global. A value with TWO quotes
+// is the case that would break out if it were not.
+mocklib.clear_commands();
+sh.try_cmd(errors, pkg.ip_full, '-4', 'route', 'replace', 'default',
+	'dev', "O'Connor", 'table', "a'b'c");
+let q = mocklib.commands()[0] || '';
+
+// ── a numeric argument survives coercion and quoting ────────────────
+mocklib.clear_commands();
+sh.try_cmd(errors, pkg.ip_full, '-4', 'rule', 'add', 'lookup', 'main',
+	'suppress_prefixlength', 1, 'pref', 30000);
+let c = mocklib.commands()[0] || '';
+
+let checks = [
+	// the redirect is what forces the shell to stay; losing it would send
+	// routine failures to the log
+	['keeps_redirect',      index(a, '>/dev/null 2>&1') >= 0],
+
+	// every word is quoted, argv0 included
+	['argv0_quoted',        index(a, "'" + pkg.ip_full + "' '-4'") >= 0],
+	['space_arg_quoted',    index(a, "'dev' 'my dev'") >= 0],
+	// and the bare, re-splittable form is gone
+	['space_arg_not_bare',  index(a, "dev my dev") < 0],
+
+	// the payload is one word inside quotes, so the shell cannot act on the ;
+	['metachar_quoted',     index(b, "'br0;touch /tmp/pbr_pwned'") >= 0],
+	['metachar_not_bare',   index(b, "dev br0;touch") < 0],
+
+	// one embedded quote, and two in the same value, both survive as data.
+	// Verified against a real /bin/sh: 'O'\''Connor' echoes back O'Connor.
+	['single_quote_escaped', index(q, "'dev' 'O'\\''Connor'") >= 0],
+	['two_quotes_escaped',   index(q, "'table' 'a'\\''b'\\''c'") >= 0],
+	// the naive rendering -- the quote left as data inside the quotes -- is
+	// what would hand the shell an unterminated string
+	['no_naive_quoting',     index(q, "'O'Connor'") < 0],
+
+	// numbers are coerced by quote() rather than reaching the shell bare
+	['number_quoted',       index(c, "'suppress_prefixlength' '1' 'pref' '30000'") >= 0],
+
+	// nothing was recorded as an error: the stub returns 0
+	['no_errors_on_success', length(errors) == 0],
+];
+
+// ── the failure path records the command in readable form ───────────
+mocklib.clear_commands();
+// note the needle is a bare word: it still matches, because it appears
+// inside the quoting the command now carries ('route' 'replace')
+mocklib.fail_command('route');
+let ok = sh.try_cmd(errors, pkg.ip_full, '-4', 'route', 'replace', 'default',
+	'dev', 'my dev', 'table', '100');
+
+push(checks, ['failure_returns_false', ok == false]);
+push(checks, ['failure_recorded',      length(errors) == 1]);
+push(checks, ['error_code',            errors[0]?.code == 'errorTryFailed']);
+// the user-facing string is the plain command, not the quoted one
+push(checks, ['error_info_unquoted',
+	errors[0]?.info == pkg.ip_full + ' -4 route replace default dev my dev table 100']);
+
+let pass = 0, fail = 0;
+for (let c in checks) {
+	if (c[1]) {
+		pass++;
+	} else {
+		fail++;
+		printf("FAIL: %s\n", c[0]);
+	}
+}
+printf("sh_try_cmd_quoted: %d/%d passed\n", pass, pass + fail);
+-- End --
+
+-- Expect stdout --
+sh_try_cmd_quoted: 15/15 passed
+-- End --

--- a/tests/lib/mocklib.uc
+++ b/tests/lib/mocklib.uc
@@ -171,6 +171,10 @@ let _captured = {};
 let _commands = [];
 let _argvs = [];
 
+/* Needles whose commands system() should report as failed. Empty by default:
+   the stub returns 0 for everything, which is what nearly every test wants. */
+let _failing = [];
+
 /* Select recorded commands: everything when needle is null, those containing
    needle when it is a string, those matching it when it is a regexp. */
 let commands_matching = (needle) => {
@@ -181,6 +185,22 @@ let commands_matching = (needle) => {
 		return filter(_commands, cmd => match(cmd, needle));
 
 	return filter(_commands, cmd => index(cmd, '' + needle) >= 0);
+};
+
+/* Same needle semantics, applied to one command as it is executed. Note the
+   needle sees the command line EXACTLY as it was handed to system(), which for
+   anything routed through sh.try_cmd() means every word is single-quoted: a
+   regexp like /route replace/ will not match `'route' 'replace'`, while the
+   bare substring "route" still does. */
+let command_fails = (cmd) => {
+	for (let needle in _failing) {
+		if (type(needle) == "regexp") {
+			if (match(cmd, needle)) return true;
+		} else if (index(cmd, '' + needle) >= 0) {
+			return true;
+		}
+	}
+	return false;
 };
 
 /* Prepend mocklib to REQUIRE_SEARCH_PATH */
@@ -266,7 +286,7 @@ global.mocklib = {
 
 	/* Drop everything recorded so far, so a test can record one phase at a
 	   time (e.g. clear after start_service() to assert on stop_service()) */
-	clear_commands: () => { _commands = []; _argvs = []; },
+	clear_commands: () => { _commands = []; _argvs = []; _failing = []; },
 
 	/* Read what system() was called with WITHOUT the join(' ') flattening that
 	   commands() applies -- an array call is returned as an array. Needed to
@@ -274,6 +294,14 @@ global.mocklib = {
 	   rather than being re-split by a shell; commands() cannot see that
 	   difference, since ['a b','c'] and ['a','b','c'] join identically. */
 	argvs: () => [ ..._argvs ],
+
+	/* Make system() return non-zero for commands matching this needle, so an
+	   error path that only runs on a failed command can be exercised. Same
+	   argument as commands(): a string matches as a substring, a regexp is
+	   matched against the command line. Call it more than once to fail more
+	   than one shape of command; clear_commands() resets the list along with
+	   the recording. */
+	fail_command: (needle) => { push(_failing, needle); },
 };
 
 /* Override stdlib functions */
@@ -288,6 +316,10 @@ global.system = function(argv, timeout) {
 
 	/* Return 1 for tty checks so output goes to logger, not stderr */
 	if (type(argv) == "string" && index(argv, "[ -t ") >= 0)
+		return 1;
+
+	if (length(_failing) &&
+	    command_fails(type(argv) == "array" ? join(' ', argv) : '' + argv))
 		return 1;
 
 	return 0;


### PR DESCRIPTION
`sh.try_cmd()` was the last place in `sys.uc` building a shell command line out of caller-supplied words without quoting them — the follow-up left open by #167.

Its 22 call sites are all `ip route replace` and `ip rule add`, carrying gateway addresses, device names and table ids. A value containing a space was re-split into two arguments; a value containing a shell metacharacter was interpreted.

## Verified on hardware, not just in the suite

x86 OpenWrt 25.12, `ucode 2026.01.16~85922056` — the same SHA the CI syntax gate pins — calling `try_cmd` directly with a real shell:

```ucode
try_cmd(e, '/bin/touch', '/tmp/q/one two')
try_cmd(e, '/bin/touch', '/tmp/q/x;touch /tmp/q/PWNED')
```

| | stock r93 | this branch |
|---|---|---|
| space-bearing argument | re-split into `one` and `two` | one file, `one two` |
| injection payload | **executed — `PWNED` created** | not executed |
| files left behind | `PWNED\|one\|two\|x\|` | `one two\|` |

So this is reachable on shipped hardware, not only in theory.

Separately, the patched `sys.uc` was deployed to that router and `pbr` restarted: it started clean, the routes `try_cmd` installs came out byte-identical to baseline (`default via 192.168.0.1 dev eth0`, `default dev wg_ch scope link`, …) and no `errorTryFailed` appeared. The quoting is transparent to real `ip`.

## Why not an argument array, like ip()

`try_cmd` goes through `run()`, which appends `>/dev/null 2>&1`, and `system()` has no fd redirection. The suppression is deliberate rather than incidental: every caller is a command whose failure is routine — a route replace on an interface that has no gateway yet — which `pbr` records as `errorTryFailed` and carries on from. Converting to an array would push those routine failures into the log.

So the shell stays and every element is `quote()`d instead, which is the rule #167 set for the calls it could not convert.

The recorded error keeps the **unquoted** join. That string is rendered as `Command failed: %s` in `service pbr status`; it is displayed, not executed, and shell quoting there would be noise the user never typed.

No call site changes — `try_cmd` takes a rest parameter, so the quoting is applied once inside it. `map()` was confirmed present on the router's own interpreter, since it is the one function the fix introduces.

## Scope

The other unquoted `sh.run()` interpolations were checked and deliberately left: `tid` comes from a `(\d+)` capture against `/etc/iproute2/rt_tables`, `priority` is computed arithmetic, `dryrun_dir` is a constant. None is a UCI-derived string, so none is this bug class.

## mocklib.fail_command()

Added because nothing could reach a failed-command path before — the `system()` stub always returned 0, so the unquoted `info` had no way of being pinned. It makes the stub report a non-zero exit for commands matching a needle, with the same needle semantics as `commands()`; `clear_commands()` resets it, and tests that do not opt in are unaffected. Same spirit as the `argvs()` recorder added in #167.

## Testing

- `tests/01_validation/06_sh_try_cmd_quoted`, 15 checks — **8/15 fail on the unfixed code**. Includes single-quote and repeated-single-quote values, which pin that `quote()`'s `'\''` escaping holds: that depends on `replace()` with a string needle being global in ucode. Checked against a real `/bin/sh` — `'O'\''Connor'` round-trips to `O'Connor`, and `'a'\''b'\''c'` to `a'b'c`
- `Ran 64 tests, 64 okay, 0 failures`
- ucode syntax gate against the pinned `85922056` build: `checked 17 file(s), 0 failed`
- no new message codes, so compat stays at 36