### PR TITLE
pbr-1.2.3: warn once when an interface has no discoverable gateway

### DIFF
--- a/files/lib/pbr/network.uc
+++ b/files/lib/pbr/network.uc
@@ -232,6 +232,18 @@ function create_network(fs_mod, config, sh, pkg, platform, V) {
 		return '';
 	}
 
+	// Record a warning unless an identical one is already there. Both gateway
+	// helpers below rewrite their interface argument to the uplink of their own
+	// address family, so on the usual wan + wan6 pair -- one device, one
+	// upstream -- processing 'wan' and then 'wan6' produces the same warning,
+	// with the same info string, twice. Two identical lines read as two faults;
+	// one interface with no gateway is one warning.
+	function push_warning_once(warnings, code, info) {
+		for (let w in warnings)
+			if (w.code == code && w.info == info) return;
+		push(warnings, { code: code, info: info });
+	}
+
 	function get_gateway4(iface, dev, warnings) {
 		if (is_uplink6(iface)) iface = cfg.uplink_interface4;
 		let gw = network_get_gateway(iface);
@@ -248,7 +260,7 @@ function create_network(fs_mod, config, sh, pkg, platform, V) {
 			}
 			// Raise warning if no gw and not point-to-point
 			if (!gw && warnings && !is_p2p(dev))
-				push(warnings, { code: 'warningInterfaceRoutingUnknownGateway4', info: 'interface:' + iface + '; device:' + dev + ' ' });
+				push_warning_once(warnings, 'warningInterfaceRoutingUnknownGateway4', 'interface:' + iface + '; device:' + dev + ' ');
 		}
 		return gw;
 	}
@@ -275,7 +287,7 @@ function create_network(fs_mod, config, sh, pkg, platform, V) {
 			}
 			// Raise warning if no gw and not point-to-point
 			if (!gw && warnings && !is_p2p(dev))
-				push(warnings, { code: 'warningInterfaceRoutingUnknownGateway6', info: 'interface:' + iface + '; device:' + dev + ' ' });
+				push_warning_once(warnings, 'warningInterfaceRoutingUnknownGateway6', 'interface:' + iface + '; device:' + dev + ' ');
 		}
 		return gw;
 	}

--- a/tests/05_interfaces/15_gateway_warning_dedupe
+++ b/tests/05_interfaces/15_gateway_warning_dedupe
@@ -1,0 +1,165 @@
+Regression: an interface with no discoverable IPv6 gateway warned twice.
+
+get_gateway6() rewrites its interface argument to cfg.uplink_interface6 when
+handed the IPv4 uplink, and get_gateway4() does the mirror image. So on the
+usual wan + wan6 pair -- one device, one upstream -- processing 'wan' and then
+processing 'wan6' both produce the warning labelled 'wan6', with the same
+device, and state.warnings had no dedupe. The user saw the identical line
+twice with nothing to distinguish the two:
+
+  WARNING: Unknown IPv6 gateway for 'interface:wan6; device:eth1 '.
+  WARNING: Unknown IPv6 gateway for 'interface:wan6; device:eth1 '.
+
+Cosmetic only -- routing was never affected -- but the repeat reads like two
+separate faults. The warning must still be raised: one interface with no
+gateway is one warning.
+
+wan6 below is up and has an address but carries no default route, and no
+popen fixture backs the 'ip -6 route'/'ip -6 neigh' fallbacks, so they come
+back empty and the gateway is genuinely undiscoverable. vpn is stripped of its
+route too, on its own device, so the test also pins down that the dedupe
+collapses identical warnings only -- a second interface that really has no
+gateway must still warn on its own account.
+
+-- File uci/pbr.json --
+{
+	"pbr": [
+		{
+			".name": "config",
+			"enabled": "1",
+			"fw_mask": "00ff0000",
+			"ipv6_enabled": "1",
+			"strict_enforcement": "1",
+			"uplink_interface": "wan",
+			"uplink_interface6": "wan6",
+			"uplink_ip_rules_priority": "30000",
+			"uplink_mark": "00010000",
+			"verbosity": "2",
+			"lan_device": ["br-lan"],
+			"resolver_instance": ["*"],
+			"debug_performance": "0",
+			"nft_set_auto_merge": "1",
+			"nft_set_flags_interval": "1",
+			"nft_set_flags_timeout": "0",
+			"nft_set_policy": "performance",
+			"ignored_interface": ["vpnserver"]
+		}
+	],
+	"policy": [
+		{
+			".name": "policy_vpn",
+			"name": "Route via VPN",
+			"enabled": "1",
+			"interface": "vpn",
+			"src_addr": "192.168.1.0/24",
+			"dest_addr": "",
+			"src_port": "",
+			"dest_port": "",
+			"proto": "",
+			"chain": "prerouting"
+		}
+	]
+}
+-- End --
+
+-- File ubus/network.interface.wan6~status.json --
+{
+	"up": true,
+	"pending": false,
+	"available": true,
+	"autostart": true,
+	"dynamic": false,
+	"uptime": 3600,
+	"l3_device": "eth1",
+	"device": "eth1",
+	"proto": "dhcpv6",
+	"ipv6-address": [
+		{
+			"address": "2001:db8::1",
+			"mask": 64
+		}
+	],
+	"route": []
+}
+-- End --
+
+-- File ubus/network.interface.vpn~status.json --
+{
+	"up": true,
+	"pending": false,
+	"available": true,
+	"autostart": true,
+	"dynamic": false,
+	"uptime": 1800,
+	"l3_device": "tun0",
+	"device": "tun0",
+	"proto": "openvpn",
+	"ipv4-address": [
+		{
+			"address": "10.8.0.2",
+			"mask": 24
+		}
+	],
+	"route": [],
+	"dns-server": [
+		"10.8.0.1"
+	]
+}
+-- End --
+
+-- Testcase --
+import create_pbr from 'pbr';
+let pbr = create_pbr();
+
+let result = pbr.start_service(['on_start']);
+let warnings = result?.warnings || [];
+
+let checks = [];
+
+// The service must still start: wan carries a v4 gateway, so the missing
+// v6 one is a warning and nothing more.
+push(checks, ['service_started', type(result?.gateways) == 'array']);
+
+// The warning is still raised -- this must not pass by warnings vanishing.
+let v6_warnings = filter(warnings,
+	w => w.code == 'warningInterfaceRoutingUnknownGateway6');
+push(checks, ['v6_warning_raised', length(v6_warnings) >= 1]);
+
+// One interface with no gateway is exactly one warning.
+let wan6_warnings = filter(v6_warnings, w => index(w.info, 'interface:wan6') >= 0);
+push(checks, ['wan6_warned_once', length(wan6_warnings) == 1]);
+
+// ... and a genuinely different interface must still get its own warning.
+// This is the guard against the dedupe collapsing too much: vpn has no
+// route either, on a different device, so it is a distinct fault.
+let vpn_warnings = filter(warnings, w => index(w.info || '', 'interface:vpn') >= 0);
+push(checks, ['vpn_warned_separately', length(vpn_warnings) >= 1]);
+push(checks, ['vpn_v4_warned_once', length(filter(vpn_warnings,
+	w => w.code == 'warningInterfaceRoutingUnknownGateway4')) == 1]);
+
+// General invariant: no two recorded warnings render the same text.
+let seen = {}, dupes = [];
+for (let w in warnings) {
+	let key = w.code + '|' + (w.info || '');
+	if (seen[key]) push(dupes, key);
+	seen[key] = true;
+}
+push(checks, ['no_duplicate_warnings', length(dupes) == 0]);
+
+let pass = 0, fail = 0;
+for (let c in checks) {
+	if (c[1]) {
+		pass++;
+	} else {
+		fail++;
+		printf("FAIL: %s\n", c[0]);
+	}
+}
+for (let d in dupes)
+	printf("DUPE: %s\n", d);
+printf("gateway_warning_dedupe: %d/%d passed\n", pass, pass + fail);
+-- End --
+
+-- Expect stdout --
+gateway_warning_dedupe: 6/6 passed
+-- End --

--- a/tests/05_interfaces/16_gateway_warning_dedupe_split_uplink
+++ b/tests/05_interfaces/16_gateway_warning_dedupe_split_uplink
@@ -1,0 +1,135 @@
+Regression: the same dedupe on a split uplink whose two halves differ.
+
+Companion to 15_gateway_warning_dedupe, which covers the default wan + wan6
+pair sharing one device. Here uplink_interface is 'wanb' (device lan1) and
+uplink_interface6 is 'wan6' (device eth1) -- the configuration a reporter
+arrived at to keep pbr starting while their primary WAN was down. The two
+uplinks are now different interfaces on different devices, so the rewrite
+inside get_gateway6() lands differently and the dedupe has to still hold.
+
+What happens without the dedupe: wanb is the IPv4 uplink, so get_gateway6()
+rewrites it to uplink_interface6 and looks up that interface's device, and
+the warning it raises is indistinguishable from the one wan6 raises for
+itself. eth1 has no IPv6 gateway here, so the identical line appears twice
+among three warnings.
+
+The 'wan' warning must survive alongside them. wan is a separate UCI section
+that is no longer either uplink, so nothing rewrites it, and its missing IPv6
+gateway is its own fact to report even though it shares eth1 with wan6. That
+is the over-collapse guard: dedupe by rendered text, never by device or by
+underlying cause.
+
+-- File uci/pbr.json --
+{
+	"pbr": [
+		{
+			".name": "config",
+			"enabled": "1",
+			"fw_mask": "00ff0000",
+			"ipv6_enabled": "1",
+			"strict_enforcement": "1",
+			"uplink_interface": "wanb",
+			"uplink_interface6": "wan6",
+			"uplink_ip_rules_priority": "30000",
+			"uplink_mark": "00010000",
+			"verbosity": "2",
+			"lan_device": ["br-lan"],
+			"resolver_instance": ["*"],
+			"debug_performance": "0",
+			"nft_set_auto_merge": "1",
+			"nft_set_flags_interval": "1",
+			"nft_set_flags_timeout": "0",
+			"nft_set_policy": "performance",
+			"ignored_interface": ["vpnserver"]
+		}
+	],
+	"policy": []
+}
+-- End --
+
+-- File uci/network.json --
+{
+	"interface": [
+		{ ".name": "loopback", "device": "lo", "proto": "static", "ipaddr": "127.0.0.1", "netmask": "255.0.0.0" },
+		{ ".name": "lan", "device": "br-lan", "proto": "static", "ipaddr": "192.168.1.1/24" },
+		{ ".name": "wan", "device": "eth1", "proto": "dhcp" },
+		{ ".name": "wan6", "device": "eth1", "proto": "dhcpv6" },
+		{ ".name": "wanb", "device": "lan1", "proto": "dhcp" }
+	]
+}
+-- End --
+
+-- File ubus/network.interface.wanb~status.json --
+{
+	"up": true, "pending": false, "available": true, "autostart": true,
+	"dynamic": false, "uptime": 3600, "l3_device": "lan1", "device": "lan1",
+	"proto": "dhcp",
+	"ipv4-address": [ { "address": "10.209.0.2", "mask": 24 } ],
+	"route": [ { "target": "0.0.0.0", "mask": 0, "nexthop": "10.209.0.1", "source": "10.209.0.2/24" } ]
+}
+-- End --
+
+-- File ubus/network.interface.wan6~status.json --
+{
+	"up": true, "pending": false, "available": true, "autostart": true,
+	"dynamic": false, "uptime": 3600, "l3_device": "eth1", "device": "eth1",
+	"proto": "dhcpv6",
+	"ipv6-address": [ { "address": "2001:db8::1", "mask": 64 } ],
+	"route": []
+}
+-- End --
+
+-- Testcase --
+import create_pbr from 'pbr';
+let pbr = create_pbr();
+
+let result = pbr.start_service(['on_start']);
+let warnings = result?.warnings || [];
+
+let checks = [];
+
+// wanb carries a v4 gateway, so the service starts and the missing v6 one
+// is a warning and nothing more.
+push(checks, ['service_started', type(result?.gateways) == 'array']);
+
+let v6 = filter(warnings, w => w.code == 'warningInterfaceRoutingUnknownGateway6');
+push(checks, ['v6_warning_raised', length(v6) >= 1]);
+
+// The dedupe: wanb rewrites to wan6, and wan6 warns for itself. One line.
+push(checks, ['wan6_warned_once',
+	length(filter(v6, w => w.info == 'interface:wan6; device:eth1 ')) == 1]);
+
+// The over-collapse guard: wan is neither uplink here, shares eth1 with
+// wan6, and must still be reported in its own right.
+push(checks, ['wan_warned_separately',
+	length(filter(v6, w => w.info == 'interface:wan; device:eth1 ')) == 1]);
+
+// Which makes exactly two distinct IPv6 warnings, not one and not three.
+push(checks, ['two_distinct_v6_warnings', length(v6) == 2]);
+
+// General invariant: no two recorded warnings render the same text.
+let seen = {}, dupes = [];
+for (let w in warnings) {
+	let key = w.code + '|' + (w.info || '');
+	if (seen[key]) push(dupes, key);
+	seen[key] = true;
+}
+push(checks, ['no_duplicate_warnings', length(dupes) == 0]);
+
+let pass = 0, fail = 0;
+for (let c in checks) {
+	if (c[1]) {
+		pass++;
+	} else {
+		fail++;
+		printf("FAIL: %s\n", c[0]);
+	}
+}
+for (let d in dupes)
+	printf("DUPE: %s\n", d);
+printf("gateway_warning_dedupe_split_uplink: %d/%d passed\n", pass, pass + fail);
+-- End --
+
+-- Expect stdout --
+gateway_warning_dedupe_split_uplink: 6/6 passed
+-- End --


### PR DESCRIPTION
A reporter running 1.2.3-r93 posted a clean start that carried the same line twice:

```
WARNING: Unknown IPv6 gateway for 'interface:wan6; device:eth1 '.
WARNING: Unknown IPv6 gateway for 'interface:wan6; device:eth1 '.
WARNING: Unknown IPv6 gateway for 'interface:wanb; device:lan1 '.
```

Cosmetic — routing is unaffected and the underlying report is correct — but the repeat reads as two separate faults, and the second line carries nothing to tell it apart from the first. The third line is a different interface and is right to be there.

## Cause

`get_gateway4()` and `get_gateway6()` each rewrite their interface argument to the uplink of their own address family before looking anything up: `get_gateway6()` maps the IPv4 uplink to `uplink_interface6`, `get_gateway4()` does the mirror image. The warning is then built from the *rewritten* name plus the device.

On the ordinary `wan` + `wan6` pair — one device, one upstream — processing `wan` produces a warning labelled `wan6`, and processing `wan6` produces the same one again. `state.warnings` had no dedupe, so both were recorded.

## A split uplink is worse off

With `uplink_interface` and `uplink_interface6` on *different* interfaces, the IPv4 uplink rewrites to `uplink_interface6` and picks up that interface's device (`pbr.uc:1122-1124`), landing on a line identical to the one the IPv6 uplink raises for itself — three warnings, two of them the same. Covered by the second test.

## What it dedupes on

Rendered text — `code` plus `info` — and nothing else. Not the device, not the underlying cause. So:

- two interfaces that genuinely have no gateway still warn separately **even when they share a device** — that is the reporter's `interface:wanb; device:lan1` line, and the `interface:wan` line a split uplink produces alongside `wan6` on the same `eth1`
- an interface whose device changed between calls still warns twice

Only an entry that would print as a byte-for-byte repeat is dropped. Both new tests assert this direction explicitly, and those assertions pass before and after the fix — they are guards against over-collapsing, not part of the reproduction.

## Verified on hardware, not just in the suite

x86 OpenWrt 25.12 (`r33164`), `ucode 2026.01.16~85922056` — the SHA the CI syntax gate pins — driving the real module with every lookup failing:

| case | stock r93 | this branch |
|---|---|---|
| default pair (`wan`+`wan6`, one device) | 2 warnings | **1** |
| IPv4 mirror | 2 warnings | **1** |
| distinct interfaces (`wan6`, `wanb`, `vpn`) | 4 warnings | **3** |
| same interface, different device | 2 warnings | 2 |

The IPv4 mirror is worth noting: `get_gateway4()` carries the same rewrite in reverse, so it had the same duplicate.

Separately, the patched `network.uc` was deployed to that box and `pbr` restarted. Against a pristine r93 run the generated `30-pbr.nft`, the IPv4 and IPv6 `ip rule` output and the `ubus` service data were all byte-identical, with `errors` and `warnings` empty in both. The dedupe is transparent wherever no duplicate exists. The file was restored to the packaged version afterwards.

## Scope

Consumers only iterate the array and test it for emptiness — `service_started` in `pbr.uc` and `status.js` in `luci-app-pbr` both — so no count changes meaning anywhere.

No message text and no message code changed, so this is not a catalog change and the compat stamp stays where it is.

The two new tests score 4/6 and 3/6 on the unfixed code.
