### PR TITLE
pbr-1.2.3: drop the obsolete regex shim from the test runner

### DIFF
--- a/tests/05_interfaces/17_tor_ports_from_torrc
+++ b/tests/05_interfaces/17_tor_ports_from_torrc
@@ -1,0 +1,103 @@
+Testing that the Tor DNS and traffic ports are read out of torrc and reach the
+generated ruleset. interface_process._get_tor_dns_port() and
+_get_tor_traffic_port() each match a single capture group, so anything that
+shifts the group index leaves them returning null -- and because the match
+itself succeeds, the '9053'/'9040' fallbacks do NOT catch it: pbr emits
+'redirect to :' with no port and nft rejects the whole file.
+
+The fixture deliberately uses 9153/9140 rather than Tor's defaults, so a helper
+that silently fell back to 9053/9040 would fail here instead of passing by
+coincidence.
+
+-- File uci/pbr.json --
+{
+	"pbr": [
+		{
+			".name": "config",
+			"enabled": "1",
+			"fw_mask": "00ff0000",
+			"ipv6_enabled": "0",
+			"resolver_set": "dnsmasq.nftset",
+			"uplink_interface": "wan",
+			"uplink_interface6": "wan6",
+			"uplink_ip_rules_priority": "30000",
+			"uplink_mark": "00010000",
+			"verbosity": "2",
+			"lan_device": ["br-lan"],
+			"resolver_instance": ["*"]
+		}
+	],
+	"policy": [
+		{
+			".name": "policy_tor",
+			"name": "Tor Clients",
+			"enabled": "1",
+			"interface": "tor",
+			"src_addr": "192.168.1.50",
+			"dest_addr": "",
+			"src_port": "",
+			"dest_port": "",
+			"proto": "",
+			"chain": ""
+		}
+	]
+}
+-- End --
+
+-- File fs/open~_etc_tor_torrc.txt --
+VirtualAddrNetwork 10.192.0.0/10
+AutomapHostsOnResolve 1
+TransPort 0.0.0.0:9140
+DNSPort 0.0.0.0:9153
+-- End --
+
+-- File fs/stat~_etc_tor_torrc.json --
+{ "type": "file", "size": 100 }
+-- End --
+
+-- File ubus/service~list~name-tor.json --
+{ "tor": { "instances": { "instance1": { "running": true } } } }
+-- End --
+
+-- Testcase --
+import create_pbr from 'pbr';
+let pbr = create_pbr();
+
+let result = pbr.start_service(['on_start']);
+let nft = global.mocklib.read_captured('/var/run/pbr.nft') || '';
+
+// Every 'redirect to :' in the ruleset must be followed by a port number.
+// A null port stringifies to ':null' and an empty one to a bare ':'; nft
+// rejects both at the whole-file 'nft -c -f' check -- the FAILED TO START
+// mode -- so match the good shape and flag everything else.
+let portless = filter(split(nft, '\n'), l => index(l, 'redirect to :') >= 0 &&
+	!match(l, /redirect to :[0-9]+ /));
+
+let checks = [
+	['dns_port_from_torrc',      index(nft, 'udp dport 53 redirect to :9153') >= 0],
+	['http_tcp_port_from_torrc', index(nft, 'tcp dport 80 redirect to :9140') >= 0],
+	['http_udp_port_from_torrc', index(nft, 'udp dport 80 redirect to :9140') >= 0],
+	['https_tcp_port_from_torrc',index(nft, 'tcp dport 443 redirect to :9140') >= 0],
+	['https_udp_port_from_torrc',index(nft, 'udp dport 443 redirect to :9140') >= 0],
+	// the fallbacks must not appear: torrc named other ports
+	['no_fallback_dns_port',     index(nft, 'redirect to :9053') < 0],
+	['no_fallback_traffic_port', index(nft, 'redirect to :9040') < 0],
+	// and no rule may be left without a port at all
+	['no_portless_redirect',     length(portless) == 0],
+];
+
+let pass = 0, fail = 0;
+for (let c in checks) {
+	if (c[1]) {
+		pass++;
+	} else {
+		fail++;
+		printf("FAIL: %s\n", c[0]);
+	}
+}
+printf("tor_ports_from_torrc: %d/%d passed\n", pass, pass + fail);
+-- End --
+
+-- Expect stdout --
+tor_ports_from_torrc: 8/8 passed
+-- End --

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -91,19 +91,6 @@ awk '
 ' "$patch_dir/pbr.uc.tmp" "$patch_dir/pbr.uc.tmp" > "$patch_dir/pbr.uc"
 rm -f "$patch_dir/pbr.uc.tmp"
 
-# Some ucode builds use POSIX ERE which lacks non-capturing groups (?:...).
-# Convert them to plain groups (...) and adjust capture-group indices.
-# get_rt_tables_id: (?:^|\\n)(\d+)...(?:\\n|$) with m[1] → (^|\\n)(\d+)...(\\n|$) with m[2]
-sed -i \
-	-e "s|regexp('(?:|regexp('(|g" \
-	-e "s|iface + '(?:|iface + '(|g" \
-	-e '/get_rt_tables_id/,/^};/ s/m\[1\]/m[2]/' \
-	"$patch_dir/pbr.uc"
-# support(): regex literal (?:option|list) → (option|list) — index shift OK (not tested)
-sed -i \
-	-e 's/(?:option/((option/' \
-	"$patch_dir/pbr.uc"
-
 trap "rm -rf '$patch_dir'" EXIT
 
 # Search paths: patched pbr.uc first, then tests/lib (for mocklib), then original source


### PR DESCRIPTION
`tests/run_tests.sh` rewrites its patched copy of `pbr.uc` to work around ucode builds that reject non-capturing groups. The tree has had none since `f716622` — `grep -rn '(?:' files/` returns nothing — so four of the five `sed` expressions match nothing at all.

The fifth is worse than dead:

```sh
-e '/get_rt_tables_id/,/^};/ s/m\[1\]/m[2]/'
```

It was written while `get_rt_tables_id` still lived in `pbr.uc`. `f716622` moved it to `nft.uc:36`, which the runner symlinks rather than patches. `pbr.uc` now holds only a call site at line 1205 and has no `^};` before 2639, so the range runs to the bottom of the file and rewrites three unrelated captures:

| patched line | what it is | effect |
|---|---|---|
| 1224 | `_get_tor_dns_port()` | returns null instead of the `DNSPort` |
| 1231 | `_get_tor_traffic_port()` | returns null instead of the `TransPort` |
| 2518 | `support()`'s config redaction | prints the wrong capture group, losing the indent |

Both Tor helpers match a single group, so `m[2]` is null — and because the match itself *succeeds*, the `'9053'`/`'9040'` fallbacks never fire. Under test pbr emits `redirect to :null`, which `nft` rejects for the whole file. Nothing fails today only because no test asserts a parsed port; it would mislead whoever writes the next one.

### Verified against the oldest supported ucode

On 25.12 hardware running ucode `2026.01.16~85922056` — the exact `UCODE_REF` `ucode-syntax.yml` pins:

- `/(?:a)(b)/` → `Repetition not preceded by valid expression`. The shim's premise was real.
- Both helper regexes expose exactly one capture group: `m[1]=9153`, `m[2]=(null)`.
- `get_rt_tables_id` as written in `nft.uc` returns `m[2]=201` correctly, with plain groups.

So the workaround was justified when it was added, and has had no target since the refactor.

### New test

`tests/05_interfaces/17_tor_ports_from_torrc`, 8 checks. The torrc fixture uses **9153/9140** rather than Tor's defaults, so a helper that silently fell back to 9053/9040 fails there instead of passing by coincidence. It asserts all five `redirect to :<port>` rules carry the torrc values, that neither fallback appears, and that no `redirect to :` is left without digits after it.

- unpatched runner: **2/8**
- shim removed: **8/8**, suite `Ran 67 tests, 67 okay, 0 failures`

Confirmed end to end on the same hardware: a real torrc with those ports puts `redirect to :9153` and `:9140` into the live kernel ruleset, matching all five assertions.

No change to shipped code — the runner only ever patches a temp copy under `/tmp/pbr_test_modules.$$`, deleted by its `EXIT` trap.
