### PR TITLE
pbr-1.2.3: keep Tor policies from breaking the ruleset when tor is down

### DIFF
--- a/files/lib/pbr/network.uc
+++ b/files/lib/pbr/network.uc
@@ -162,10 +162,22 @@ function create_network(fs_mod, config, sh, pkg, platform, V) {
 		return V.str_contains(cfg.lan_device, d);
 	}
 	function is_ignored_interface(iface) { return V.str_contains_word(cfg.ignored_interface, iface); }
-	function is_tor_running() {
+	// Tor is usable as a policy target as soon as it is CONFIGURED: the
+	// redirect ports come out of torrc, not out of the running daemon. pbr is
+	// START=20 and OpenWrt's tor is START=50, so at boot the service is never
+	// up yet -- gating the port lookup on it left interface_process.tor()
+	// unrun, the ports empty, and every Tor rule interpolating 'redirect to :',
+	// which nft rejects for the whole file.
+	function is_tor_configured() {
 		if (is_ignored_interface('tor')) return false;
 		let content = readfile(pkg.tor_config_file);
-		if (!content || content == '') return false;
+		return !!(content && content != '');
+	}
+	// Whether the daemon is actually up. Fine for reporting, but do NOT gate
+	// rule generation on it: the ports live in torrc, the emitter keys off the
+	// policy's interface name alone, and pbr starts before tor at boot.
+	function is_tor_running() {
+		if (!is_tor_configured()) return false;
 		let svc = config.ubus_call('service', 'list', { name: 'tor' });
 		if (!svc?.tor?.instances) return false;
 		for (let k in keys(svc.tor.instances)) {
@@ -196,6 +208,10 @@ function create_network(fs_mod, config, sh, pkg, platform, V) {
 	function is_supported_interface(iface) {
 		if (!iface) return false;
 		if (is_lan(iface) || is_disabled_interface(iface)) return false;
+		// Checked ahead of supported_interface: without a torrc there are no
+		// ports to redirect to, so a Tor policy cannot produce a usable rule
+		// however the interface was listed.
+		if (is_tor(iface)) return is_tor_configured();
 		if (V.str_contains_word(cfg.supported_interface, iface)) return true;
 		if (!is_ignored_interface(iface) && (is_uplink(iface) || is_wan(iface) || is_tunnel(iface))) return true;
 		if (is_ignore_target(iface)) return true;
@@ -424,7 +440,7 @@ function create_network(fs_mod, config, sh, pkg, platform, V) {
 		is_point_to_point, is_xfrm, is_p2p,
 		is_wan, is_uplink, is_uplink4, is_uplink6, is_split_uplink,
 		is_default_dev, is_disabled_interface, is_lan,
-		is_ignored_interface, is_tor_running,
+		is_ignored_interface, is_tor_running, is_tor_configured,
 		is_ignore_target, is_netifd_table, is_netifd_interface,
 		is_mwan4_interface, is_netifd_interface_default,
 		is_supported_protocol, is_mwan4_strategy,

--- a/files/lib/pbr/pbr.uc
+++ b/files/lib/pbr/pbr.uc
@@ -166,7 +166,7 @@ function create_pbr(fs_mod, uci_mod, ubus_mod) {
 			push(state.errors, { code: 'errorDefaultFw4TableMissing', info: 'fw4' });
 			health_fail = true;
 		}
-		if (net.is_config_enabled('dns_policy') || net.is_tor_running()) {
+		if (net.is_config_enabled('dns_policy') || net.is_tor_configured()) {
 			if (!nft.nft_check_element('chain', 'dstnat')) {
 				push(state.errors, { code: 'errorDefaultFw4ChainMissing', info: 'dstnat' });
 				health_fail = true;
@@ -573,6 +573,16 @@ function create_pbr(fs_mod, uci_mod, ubus_mod) {
 	
 			if (net.is_tor(iface)) {
 				let ipv4_error = false, ipv6_error = false;
+				// Belt and braces. is_supported_interface() already rejects a
+				// Tor policy on a box with no torrc, so this should be
+				// unreachable -- but an empty port renders as 'redirect to :'
+				// and nft rejects the ENTIRE file for it, taking every other
+				// policy down with it. Never let one out of this function.
+				if (!env.tor_dns_port || !env.tor_traffic_port) {
+					process_policy_error = true;
+					push(state.errors, { code: 'errorPolicyUnknownInterface', info: name });
+					return 1;
+				}
 				chain = 'dstnat';
 				let p4_base = nft_insert + ' rule inet ' + nft_table + ' ' + nft_prefix + '_' + chain +
 					rule_params + ' meta nfproto ipv4 ' + param4;
@@ -2041,7 +2051,7 @@ function create_pbr(fs_mod, uci_mod, ubus_mod) {
 				interface_process.create(s['.name']);
 			});
 			interface_process.tor('destroy');
-			if (net.is_tor_running()) interface_process.tor('create');
+			if (net.is_tor_configured()) interface_process.tor('create');
 			interface_process.create_global_rules();
 			sh.run(pkg.ip_full + ' route flush cache');
 			end_time = time();

--- a/tests/05_interfaces/18_tor_ports_without_running_service
+++ b/tests/05_interfaces/18_tor_ports_without_running_service
@@ -1,0 +1,115 @@
+Testing that a Tor policy builds a valid ruleset when torrc is present but the
+Tor service is NOT running.
+
+The redirect ports come out of torrc, not out of the running daemon, but
+interface_process.tor('create') -- the only thing that fills env.tor_dns_port
+and env.tor_traffic_port -- used to be gated on net.is_tor_running(). The rule
+emitter gates only on the policy's interface NAME, so with the service down it
+interpolated an empty port and emitted 'redirect to :', which nft rejects for
+the WHOLE file: pbr fails to start and every other policy stops routing too.
+
+This is not an exotic state. pbr is START=20 and OpenWrt's tor is START=50, so
+at boot the service is never up yet.
+
+There is deliberately no ubus service~list fixture here, so is_tor_running() is
+false while torrc is readable.
+
+-- File uci/pbr.json --
+{
+	"pbr": [
+		{
+			".name": "config",
+			"enabled": "1",
+			"fw_mask": "00ff0000",
+			"ipv6_enabled": "0",
+			"resolver_set": "dnsmasq.nftset",
+			"uplink_interface": "wan",
+			"uplink_interface6": "wan6",
+			"uplink_ip_rules_priority": "30000",
+			"uplink_mark": "00010000",
+			"verbosity": "2",
+			"lan_device": ["br-lan"],
+			"resolver_instance": ["*"]
+		}
+	],
+	"policy": [
+		{
+			".name": "policy_tor",
+			"name": "Tor Clients",
+			"enabled": "1",
+			"interface": "tor",
+			"src_addr": "192.168.1.50",
+			"dest_addr": "",
+			"src_port": "",
+			"dest_port": "",
+			"proto": "",
+			"chain": ""
+		},
+		{
+			".name": "policy_wan",
+			"name": "Plain Wan",
+			"enabled": "1",
+			"interface": "wan",
+			"src_addr": "192.168.1.51",
+			"dest_addr": "",
+			"src_port": "",
+			"dest_port": "",
+			"proto": "",
+			"chain": ""
+		}
+	]
+}
+-- End --
+
+-- File fs/open~_etc_tor_torrc.txt --
+VirtualAddrNetwork 10.192.0.0/10
+AutomapHostsOnResolve 1
+TransPort 0.0.0.0:9140
+DNSPort 0.0.0.0:9153
+-- End --
+
+-- File fs/stat~_etc_tor_torrc.json --
+{ "type": "file", "size": 100 }
+-- End --
+
+-- Testcase --
+import create_pbr from 'pbr';
+let pbr = create_pbr();
+
+let result = pbr.start_service(['on_start']);
+let errors = map(result.errors || [], e => e.code);
+let nft = global.mocklib.read_captured('/var/run/pbr.nft') || '';
+
+// A missing port renders as 'redirect to :' (or ':null'); nft rejects the
+// whole file for it. Match the good shape and flag everything else.
+let portless = filter(split(nft, '\n'), l => index(l, 'redirect to :') >= 0 &&
+	!match(l, /redirect to :[0-9]+ /));
+
+let checks = [
+	// the ports must come from torrc even with the daemon down
+	['dns_port_emitted',      index(nft, 'udp dport 53 redirect to :9153') >= 0],
+	['http_port_emitted',     index(nft, 'tcp dport 80 redirect to :9140') >= 0],
+	['https_port_emitted',    index(nft, 'tcp dport 443 redirect to :9140') >= 0],
+	['no_portless_redirect',  length(portless) == 0],
+	// torrc is present, so the policy is legitimate and must not be rejected
+	['tor_policy_accepted',   index(errors, 'errorPolicyUnknownInterface') < 0],
+	// and the unrelated policy must be unaffected
+	['wan_policy_routed',     index(nft, 'policy_wan') >= 0 ||
+	                          index(nft, '192.168.1.51') >= 0],
+];
+
+let pass = 0, fail = 0;
+for (let c in checks) {
+	if (c[1]) {
+		pass++;
+	} else {
+		fail++;
+		printf("FAIL: %s\n", c[0]);
+	}
+}
+printf("tor_ports_without_running_service: %d/%d passed\n", pass, pass + fail);
+-- End --
+
+-- Expect stdout --
+tor_ports_without_running_service: 6/6 passed
+-- End --

--- a/tests/05_interfaces/19_tor_policy_without_torrc
+++ b/tests/05_interfaces/19_tor_policy_without_torrc
@@ -1,0 +1,100 @@
+Testing that a Tor policy on a box with no torrc is rejected cleanly instead of
+poisoning the ruleset.
+
+Without a torrc there are no ports to redirect to, so the policy cannot produce
+a usable rule however the interface was listed. is_supported_interface() now
+answers false for 'tor' in that state, so the policy is rejected the same way
+any other unavailable interface is -- pbr starts, the ruleset stays valid, and
+every other policy keeps routing.
+
+Previously is_tunnel() called 'tor' supported unconditionally, the policy was
+accepted, and the emitter produced 'redirect to :' with an empty port.
+
+There is deliberately no torrc fixture here.
+
+-- File uci/pbr.json --
+{
+	"pbr": [
+		{
+			".name": "config",
+			"enabled": "1",
+			"fw_mask": "00ff0000",
+			"ipv6_enabled": "0",
+			"resolver_set": "dnsmasq.nftset",
+			"uplink_interface": "wan",
+			"uplink_interface6": "wan6",
+			"uplink_ip_rules_priority": "30000",
+			"uplink_mark": "00010000",
+			"verbosity": "2",
+			"lan_device": ["br-lan"],
+			"resolver_instance": ["*"]
+		}
+	],
+	"policy": [
+		{
+			".name": "policy_tor",
+			"name": "Tor Clients",
+			"enabled": "1",
+			"interface": "tor",
+			"src_addr": "192.168.1.50",
+			"dest_addr": "",
+			"src_port": "",
+			"dest_port": "",
+			"proto": "",
+			"chain": ""
+		},
+		{
+			".name": "policy_wan",
+			"name": "Plain Wan",
+			"enabled": "1",
+			"interface": "wan",
+			"src_addr": "192.168.1.51",
+			"dest_addr": "",
+			"src_port": "",
+			"dest_port": "",
+			"proto": "",
+			"chain": ""
+		}
+	]
+}
+-- End --
+
+-- Testcase --
+import create_pbr from 'pbr';
+let pbr = create_pbr();
+
+let result = pbr.start_service(['on_start']);
+let errors = map(result.errors || [], e => e.code);
+let nft = global.mocklib.read_captured('/var/run/pbr.nft') || '';
+
+let checks = [
+	// rejected, and named so the user can find it
+	['tor_policy_rejected', index(errors, 'errorPolicyUnknownInterface') >= 0],
+	['names_the_policy',    length(filter(result.errors || [], e =>
+		e.code == 'errorPolicyUnknownInterface' && e.info == 'Tor Clients')) == 1],
+	// nothing tor-shaped reaches the ruleset
+	['no_redirect_rule',    index(nft, 'redirect to') < 0],
+	// the pbr_dstnat chain is created unconditionally; what must not exist is
+	// a rule in it
+	['no_dstnat_rule',      length(filter(split(nft, '\n'),
+		l => index(l, 'add rule') >= 0 && index(l, 'pbr_dstnat') >= 0)) == 0],
+	// the rest of the ruleset survives -- this is the whole point of rejecting
+	// the policy rather than emitting a rule nft will refuse
+	['wan_policy_routed',   index(nft, '192.168.1.51') >= 0],
+];
+
+let pass = 0, fail = 0;
+for (let c in checks) {
+	if (c[1]) {
+		pass++;
+	} else {
+		fail++;
+		printf("FAIL: %s\n", c[0]);
+	}
+}
+printf("tor_policy_without_torrc: %d/%d passed\n", pass, pass + fail);
+-- End --
+
+-- Expect stdout --
+tor_policy_without_torrc: 5/5 passed
+-- End --


### PR DESCRIPTION
A Tor policy on a box where torrc exists but the tor daemon is not running takes the **whole ruleset** down:

```
Installing fw4 nft file [x]
pbr 1.2.3-r93 FAILED TO START!!!
/var/run/pbr.nft:40:111-117: Error: syntax error, unexpected comment
add rule inet fw4 pbr_dstnat … udp dport 53 redirect to : comment "Tor-DNS-UDP"
                                                        ^^^^^^^
```

### Cause

`env.tor_dns_port` / `tor_traffic_port` start empty (`platform.uc:35-36`) and were only filled by `interface_process.tor('create')`, which `pbr.uc:2044` gated on `net.is_tor_running()`. The rule emitter at `pbr.uc:574` gates on `net.is_tor(iface)` — the policy's interface **name** — and `is_supported_interface()` called tor supported unconditionally through `is_tunnel()` (`network.uc:117`).

The two sites disagreed, so the emitter interpolated an empty port and nft rejected the entire file. pbr fails to start and every other policy stops routing with it.

This is not an exotic state:

- pbr is `START=20`, OpenWrt's tor is `START=50` — at boot the daemon is never up yet.
- LuCI offers `tor` in the interface dropdown on nothing more than `stat('/etc/tor/torrc')` (`network.uc:369`).
- `is_tor_running()` also gated the health check that verifies fw4's `dstnat` chain exists, so in this state pbr emitted dstnat rules without having checked for the chain.

### Fix

The ports live in torrc, not in the running daemon, so read them whenever tor is **configured**:

- **`is_tor_configured()`** — torrc readable and tor not ignored. Registration and the `dstnat` health check gate on this instead of `is_tor_running()`, so the rules are right while tor is starting and begin working the moment it comes up.
- **`is_supported_interface()` answers false for `tor` with no torrc**, so such a policy is rejected like any other unavailable interface rather than emitting a rule nft will refuse. Uses the existing `errorPolicyUnknownInterface` — no new message code, **compat stays at 36**, no companion luci PR.
- **A guard in the emitter** refuses to build a Tor rule without a port. It should now be unreachable; an empty port costs the whole ruleset, so it is not left to reachability arguments.

`is_tor_running()` is kept — still the honest answer for reporting — with a comment saying not to gate rule generation on it again.

### Tests

| | with fix | without |
|---|---|---|
| `05_interfaces/18_tor_ports_without_running_service` | 6/6 | **2/6** |
| `05_interfaces/19_tor_policy_without_torrc` | 5/5 | **1/5** |

Suite: `Ran 69 tests, 69 okay, 0 failures`.

### Verified on hardware

x86 25.12 r33164, nftables 1.1.6, pbr 1.2.3-r93, ucode `2026.01.16~85922056` — the oldest supported, and both modules compile under it. Patch applied to the router's own r93 files, so the delta is exactly this change.

| scenario | stock r93 | patched |
|---|---|---|
| torrc present, tor **not installed**, tor policy | FAILED TO START, `redirect to :` ×5 | starts clean, reports `tor/53->9153/80,443->9140`, all five rules carry the torrc ports in the live kernel ruleset, `nft -c -f` accepts |
| torrc removed, tor policy kept | same failure | starts clean, `ERROR: Policy 'Claude Tor Port Test' has an unknown interface!`, 0 redirect rules, 0 dstnat rules, the other 69 policy rules intact |

The torrc fixture uses 9153/9140 rather than Tor's defaults throughout, so a code path that silently fell back to 9053/9040 would fail rather than pass by coincidence.

Depends on #174 — before that merged, the test harness rewrote both Tor port helpers to read a capture group that does not exist, so none of this was testable.
