### PR TITLE
pbr-1.2.3: bump PKG_RELEASE from 97 to 99

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=pbr
 PKG_VERSION:=1.2.3
-PKG_RELEASE:=97
+PKG_RELEASE:=99
 PKG_LICENSE:=AGPL-3.0-or-later
 PKG_MAINTAINER:=Stan Grishin <stangri@melmac.ca>, Erik Conijn <egc112@msn.com>
 


### PR DESCRIPTION
What changed since **1.2.3-r97**.

One fix, in the WebUI:

- **A warning you have just corrected now clears on its own.** Previously, fixing a policy the service had complained about and hitting *Save & Apply* left the old warning on screen until you reloaded the page by hand — which read as though the correction had not worked. The status panel now re-checks after an apply and updates once the service has settled.

This became noticeable in r97, which is the release that started reporting a policy's `Protocol` setting when it cannot take effect. Correcting one of those and watching the warning sit there was the obvious way to hit it.

Nothing else changed. `pbr` itself carries no code changes in this release; it is bumped to stay in lockstep with `luci-app-pbr`, which the two packages require of each other.

`PKG_RELEASE` on the `1.2.3` branch moves in steps of two and stays odd — …93, 95, 97, 99. r98 is not a skipped release; there is no even number in this series.

Paired with https://github.com/mossdef-org/luci-app-pbr/pull/51
