### PR TITLE
pbr.user.dnsprefetch: wait for service completion

### DIFF
--- a/files/usr/share/pbr/pbr.user.dnsprefetch
+++ b/files/usr/share/pbr/pbr.user.dnsprefetch
@@ -38,9 +38,10 @@
 # wait here made "/etc/init.d/pbr reload" take 62s instead of 3s). So the first
 # pass records the pbr ucode worker's pid, re-executes this file in its own
 # session and returns immediately. The detached copy waits for that worker to
-# exit: only then have fw4 reload, set cleanup and the resolver restart/cache
-# flush all completed. Watching the nft file is too early because pbr copies it
-# before running fw4; a fixed delay raced dnsmasq on large configurations.
+# exit: only then have fw4 reload, set cleanup and pbr's resolver restart/cache
+# flush request all completed. dnsmasq may still be applying that request, so
+# its readiness is probed below. Watching the nft file is too early because pbr
+# copies it before running fw4; a fixed delay raced dnsmasq on large setups.
 #
 # The service sources this file, so it cannot discover its own path ($0 is the
 # sourcing shell). Update this if you install it somewhere else.
@@ -89,17 +90,17 @@ else
 			''|*[!0-9]*|0|1) return 2 ;;
 		esac
 
+		output "Waiting for $packageName run (pid $pbr_pid) to finish..."
 		while kill -0 "$pbr_pid" 2>/dev/null; do
 			[ "$timeout_pbr_run" -eq '0' ] && return 1
 			sleep '1' && timeout_pbr_run="$((timeout_pbr_run - 1))"
 		done
 	}
 
-	# Fallback for an explicitly forced child invocation, where there is no pbr
-	# worker pid to follow. Normal service starts never take this path.
-	#
-	# Modification time of the ruleset pbr installs, or the empty string before
-	# the first one exists.
+	# The mtime fallback is used only when there is no usable pbr worker pid to
+	# follow, such as an explicitly forced child invocation. Normal service starts
+	# never take this path. Return the ruleset's modification time, or the empty
+	# string before the first one exists.
 	nft_stamp() {
 		[ -f "$packageNftFile" ] || return 0
 		date -r "$packageNftFile" +%s 2>/dev/null
@@ -120,6 +121,16 @@ else
 			[ "$timeout_nft_file" -eq '0' ] && return 1
 			sleep '1' && timeout_nft_file="$((timeout_nft_file - 1))"
 		done
+	}
+
+	pbr_ruleset_fallback_finished() {
+		local settle='15'
+		local stamp_before
+
+		output "$packageName worker pid unavailable, using ruleset fallback..."
+		stamp_before="$(nft_stamp)"
+		nft_file_installed "$stamp_before" || return 1
+		sleep "$settle"
 	}
 
 	nft_ready() {
@@ -173,25 +184,30 @@ else
 		output="$(nslookup "$1" 127.0.0.1)" && { echo '0' > "$pipe_nslookup"; return; }
 		reason="$(printf '%s' "$output" | grep -Eo -m 1 'NXDOMAIN|SERVFAIL|timed out')" && \
 		output "$_WARNING_ Lookup failed for $1 ($reason)"
-		echo '1' > "$pipe_nslookup"
+		[ "$reason" = 'NXDOMAIN' ] && echo '2' > "$pipe_nslookup" || echo '1' > "$pipe_nslookup"
 	}
 
 	nslookup_tracker() {
-		local entries errors result
+		local entries errors hard_errors result
 
 		while read -r rc; do
 			entries="$((entries + 1))"
-			[ "$rc" -eq '1' ] && errors="$((errors + 1))"
+			[ "$rc" -ne '0' ] && errors="$((errors + 1))"
+			[ "$rc" -eq '1' ] && hard_errors="$((hard_errors + 1))"
 		done < "$pipe_nslookup"
 
-		[ "${errors:-0}" -eq '0' ] && result="$__OK__" || result="$__FAIL__"
+		# NXDOMAIN is a valid DNS reply and may be permanent or intentional. Keep
+		# counting it, but reserve the failure marker for timeouts, SERVFAIL and
+		# other cases where no usable answer was received.
+		[ "${hard_errors:-0}" -eq '0' ] && result="$__OK__" || result="$__FAIL__"
 		output "Finished resolving $entries domain names in policies (${errors:-0} failed) $result"
 	}
 
 	main() {
 		local msg_abort='domain names in policies not resolved'
-		local settle='15'
-		local stamp_before domain
+		local barrier_rc='2'
+		local used_fallback='0'
+		local domain
 		local rc='0'
 
 		# $resolverSetSupported is not available here; read the setting pbr
@@ -207,18 +223,24 @@ else
 		mkfifo "$pipe_nslookup"
 
 		if [ -n "$PBR_DNSPREFETCH_PARENT_PID" ]; then
-			pbr_run_finished "$PBR_DNSPREFETCH_PARENT_PID" || {
+			pbr_run_finished "$PBR_DNSPREFETCH_PARENT_PID"
+			barrier_rc="$?"
+		fi
+
+		case "$barrier_rc" in
+			0) ;;
+			2)
+				used_fallback='1'
+				pbr_ruleset_fallback_finished || {
+					output "Timed out waiting for $packageName to install its ruleset, $msg_abort $__FAIL__"
+					rc='1'
+				}
+				;;
+			*)
 				output "Timed out waiting for $packageName to finish its run, $msg_abort $__FAIL__"
 				rc='1'
-			}
-		else
-			stamp_before="$(nft_stamp)"
-			nft_file_installed "$stamp_before" || {
-				output "Timed out waiting for $packageName to install its ruleset, $msg_abort $__FAIL__"
-				rc='1'
-			}
-			[ "$rc" -eq '0' ] && sleep "$settle"
-		fi
+				;;
+		esac
 
 		[ "$rc" -eq '0' ] && [ ! -f "$packageDnsmasqFile" ] && {
 			output "File $packageDnsmasqFile not found, $msg_abort $__FAIL__"
@@ -234,31 +256,31 @@ else
 			rc='1'
 		}
 
-		[ "$rc" -eq '0' ] && {
-			# dnsmasq only writes to an nft set on an upstream reply, so a name
-			# still in its cache would be answered without filling the set.
-			# pbr has already cleared the cache by this point on both of its
-			# paths, but doing it here too costs nothing and keeps this correct
-			# whichever path ran, and whatever the timing. Only ever after
-			# dnsmasq_ready() -- see the note there.
+		# On the parent-pid path pbr has already restarted dnsmasq or sent the
+		# cache-flushing HUP before its worker exited. Repeating it would force a
+		# second expensive re-read of large hosts/adblock configurations. The
+		# fallback cannot make that guarantee, so retain the flush there. Wait one
+		# second before probing to ensure the first answer cannot race ahead of
+		# dnsmasq handling the signal.
+		[ "$rc" -eq '0' ] && [ "$used_fallback" -eq '1' ] && {
 			killall -q -s HUP dnsmasq
-			# On large hosts/adblock configurations SIGHUP itself can take longer
-			# than the old one-second delay. A reply proves the final daemon has
-			# completed the cache flush and returned to its event loop.
-			if ! dnsmasq_ready; then
+			sleep '1'
+			! dnsmasq_ready && {
 				output "Dnsmasq is not answering after cache flush, $msg_abort $__FAIL__"
 				rc='1'
-			else
-				nslookup_tracker & exec 3>"$pipe_nslookup"
-				(
-					output "Resolving domain names in policies..."
-					while IFS='/' read -r _ domain _; do
-						[ -n "$domain" ] && run_nslookup "$domain" &
-					done < "$packageDnsmasqFile"
-					wait
-				)
-				exec 3>&-
-			fi
+			}
+		}
+
+		[ "$rc" -eq '0' ] && {
+			nslookup_tracker & exec 3>"$pipe_nslookup"
+			(
+				output "Resolving domain names in policies..."
+				while IFS='/' read -r _ domain _; do
+					[ -n "$domain" ] && run_nslookup "$domain" &
+				done < "$packageDnsmasqFile"
+				wait
+			)
+			exec 3>&-
 		}
 
 		rm -f "$pipe_nslookup"

--- a/files/usr/share/pbr/pbr.user.dnsprefetch
+++ b/files/usr/share/pbr/pbr.user.dnsprefetch
@@ -204,9 +204,12 @@ else
 		done < "$pipe_nslookup"
 
 		# NXDOMAIN is a valid DNS reply and may be permanent or intentional. Keep
-		# counting it, but reserve the failure marker for timeouts, SERVFAIL and
-		# other cases where no usable answer was received.
-		[ "${hard_errors:-0}" -eq '0' ] && result="$__OK__" || result="$__FAIL__"
+		# counting it without failing a partly successful run. Timeouts, SERVFAIL
+		# and other hard errors fail immediately; an all-NXDOMAIN run also fails
+		# because it did not resolve a single domain into a set.
+		result="$__OK__"
+		[ "${hard_errors:-0}" -ne '0' ] && result="$__FAIL__"
+		[ "${entries:-0}" -gt '0' ] && [ "${errors:-0}" -eq "$entries" ] && result="$__FAIL__"
 		output "Finished resolving $entries domain names in policies (${errors:-0} failed) $result"
 	}
 

--- a/files/usr/share/pbr/pbr.user.dnsprefetch
+++ b/files/usr/share/pbr/pbr.user.dnsprefetch
@@ -36,8 +36,11 @@
 # pbr waits for every process this file leaves running -- a plain "&" is not
 # enough, and a background job that waits for pbr to finish deadlocks it (a 60s
 # wait here made "/etc/init.d/pbr reload" take 62s instead of 3s). So the first
-# pass only re-executes this file in its own session and returns immediately;
-# all of the real work happens in that detached copy, after pbr has moved on.
+# pass records the pbr ucode worker's pid, re-executes this file in its own
+# session and returns immediately. The detached copy waits for that worker to
+# exit: only then have fw4 reload, set cleanup and the resolver restart/cache
+# flush all completed. Watching the nft file is too early because pbr copies it
+# before running fw4; a fixed delay raced dnsmasq on large configurations.
 #
 # The service sources this file, so it cannot discover its own path ($0 is the
 # sourcing shell). Update this if you install it somewhere else.
@@ -45,7 +48,9 @@ _dnsprefetch_self='/usr/share/pbr/pbr.user.dnsprefetch'
 
 if [ -z "$PBR_DNSPREFETCH_CHILD" ]; then
 	if [ -f "$_dnsprefetch_self" ]; then
-		PBR_DNSPREFETCH_CHILD=1 setsid /bin/sh "$_dnsprefetch_self" </dev/null >/dev/null 2>&1 &
+		PBR_DNSPREFETCH_CHILD=1 \
+		PBR_DNSPREFETCH_PARENT_PID="$PPID" \
+		setsid /bin/sh "$_dnsprefetch_self" </dev/null >/dev/null 2>&1 &
 	else
 		# The only failure this script cannot report from the detached copy,
 		# since there is nothing to detach. pbr logs that it ran the file but
@@ -76,6 +81,22 @@ else
 	# might run this, and being generous is free -- each loop returns the
 	# moment its condition is met, so a fast router never spends the budget.
 	# Only a genuine failure waits it out, and then the abort is logged.
+	pbr_run_finished() {
+		local timeout_pbr_run='300'
+		local pbr_pid="$1"
+
+		case "$pbr_pid" in
+			''|*[!0-9]*|0|1) return 2 ;;
+		esac
+
+		while kill -0 "$pbr_pid" 2>/dev/null; do
+			[ "$timeout_pbr_run" -eq '0' ] && return 1
+			sleep '1' && timeout_pbr_run="$((timeout_pbr_run - 1))"
+		done
+	}
+
+	# Fallback for an explicitly forced child invocation, where there is no pbr
+	# worker pid to follow. Normal service starts never take this path.
 	#
 	# Modification time of the ruleset pbr installs, or the empty string before
 	# the first one exists.
@@ -156,14 +177,15 @@ else
 	}
 
 	nslookup_tracker() {
-		local entries errors
+		local entries errors result
 
 		while read -r rc; do
 			entries="$((entries + 1))"
 			[ "$rc" -eq '1' ] && errors="$((errors + 1))"
 		done < "$pipe_nslookup"
 
-		output "Finished resolving $entries domain names in policies (${errors:-0} failed) $__OK__"
+		[ "${errors:-0}" -eq '0' ] && result="$__OK__" || result="$__FAIL__"
+		output "Finished resolving $entries domain names in policies (${errors:-0} failed) $result"
 	}
 
 	main() {
@@ -180,24 +202,24 @@ else
 			return 1
 		}
 
-		stamp_before="$(nft_stamp)"
 		# Nothing else cleans this up if the prefetch is killed part-way.
 		trap 'rm -f "$pipe_nslookup"' EXIT HUP INT TERM
 		mkfifo "$pipe_nslookup"
 
-		nft_file_installed "$stamp_before" || {
-			output "Timed out waiting for $packageName to install its ruleset, $msg_abort $__FAIL__"
-			rc='1'
-		}
-		# Give pbr the rest of its run: it reaps orphaned sets and drops
-		# addresses for domains whose policy changed just after installing the
-		# ruleset, and either of those would discard what we resolve here.
-		# Both are a handful of nft calls issued right after the ruleset goes
-		# in, so this does not have to cover pbr's slow work -- the two long
-		# waits either side of it do. It is padded for a slow router all the
-		# same, and costs nothing on a fast one: it runs in the detached copy,
-		# never in the reload.
-		[ "$rc" -eq '0' ] && sleep "$settle"
+		if [ -n "$PBR_DNSPREFETCH_PARENT_PID" ]; then
+			pbr_run_finished "$PBR_DNSPREFETCH_PARENT_PID" || {
+				output "Timed out waiting for $packageName to finish its run, $msg_abort $__FAIL__"
+				rc='1'
+			}
+		else
+			stamp_before="$(nft_stamp)"
+			nft_file_installed "$stamp_before" || {
+				output "Timed out waiting for $packageName to install its ruleset, $msg_abort $__FAIL__"
+				rc='1'
+			}
+			[ "$rc" -eq '0' ] && sleep "$settle"
+		fi
+
 		[ "$rc" -eq '0' ] && [ ! -f "$packageDnsmasqFile" ] && {
 			output "File $packageDnsmasqFile not found, $msg_abort $__FAIL__"
 			rc='1'
@@ -220,16 +242,23 @@ else
 			# whichever path ran, and whatever the timing. Only ever after
 			# dnsmasq_ready() -- see the note there.
 			killall -q -s HUP dnsmasq
-			sleep '1'
-			nslookup_tracker & exec 3>"$pipe_nslookup"
-			(
-				output "Resolving domain names in policies..."
-				while IFS='/' read -r _ domain _; do
-					[ -n "$domain" ] && run_nslookup "$domain" &
-				done < "$packageDnsmasqFile"
-				wait
-			)
-			exec 3>&-
+			# On large hosts/adblock configurations SIGHUP itself can take longer
+			# than the old one-second delay. A reply proves the final daemon has
+			# completed the cache flush and returned to its event loop.
+			if ! dnsmasq_ready; then
+				output "Dnsmasq is not answering after cache flush, $msg_abort $__FAIL__"
+				rc='1'
+			else
+				nslookup_tracker & exec 3>"$pipe_nslookup"
+				(
+					output "Resolving domain names in policies..."
+					while IFS='/' read -r _ domain _; do
+						[ -n "$domain" ] && run_nslookup "$domain" &
+					done < "$packageDnsmasqFile"
+					wait
+				)
+				exec 3>&-
+			fi
 		}
 
 		rm -f "$pipe_nslookup"

--- a/files/usr/share/pbr/pbr.user.dnsprefetch
+++ b/files/usr/share/pbr/pbr.user.dnsprefetch
@@ -49,8 +49,15 @@ _dnsprefetch_self='/usr/share/pbr/pbr.user.dnsprefetch'
 
 if [ -z "$PBR_DNSPREFETCH_CHILD" ]; then
 	if [ -f "$_dnsprefetch_self" ]; then
+		# $PPID is pbr's ucode worker: the service hands the user-file wrapper
+		# to /bin/sh -c, so the shell sourcing this file is a direct child of the
+		# worker, and sourcing does not fork. Confirm it rather than trust it --
+		# run by hand, $PPID is a login shell that may never exit.
+		_dnsprefetch_parent="$PPID"
+		tr '\0' ' ' < "/proc/$PPID/cmdline" 2>/dev/null |
+			grep -q '/lib/pbr/cli\.uc' || _dnsprefetch_parent=''
 		PBR_DNSPREFETCH_CHILD=1 \
-		PBR_DNSPREFETCH_PARENT_PID="$PPID" \
+		PBR_DNSPREFETCH_PARENT_PID="$_dnsprefetch_parent" \
 		setsid /bin/sh "$_dnsprefetch_self" </dev/null >/dev/null 2>&1 &
 	else
 		# The only failure this script cannot report from the detached copy,
@@ -257,10 +264,9 @@ else
 		}
 
 		# On the parent-pid path pbr has already restarted dnsmasq or sent the
-		# cache-flushing HUP before its worker exited. Repeating it would force a
-		# second expensive re-read of large hosts/adblock configurations. The
-		# fallback cannot make that guarantee, so retain the flush there. Wait one
-		# second before probing to ensure the first answer cannot race ahead of
+		# cache-flushing HUP before its worker exited, so repeating it is redundant.
+		# The fallback cannot make that guarantee, so retain the flush there. Wait
+		# one second before probing to ensure the first answer cannot race ahead of
 		# dnsmasq handling the signal.
 		[ "$rc" -eq '0' ] && [ "$used_fallback" -eq '1' ] && {
 			killall -q -s HUP dnsmasq


### PR DESCRIPTION
## Problem

pbr.user.dnsprefetch currently treats the nft ruleset file mtime as a signal that the service is ready, then waits a fixed 15 seconds. The file is copied before fw4 reload, resolver cleanup, and the subsequent dnsmasq restart/cache flush have completed.

On a GL-MT6000 with a large adblock configuration (dnsmasq reports 464,589 additional local addresses), the prefetch started while dnsmasq was still being replaced. All 106 parallel lookups then timed out, even though direct queries to 1.1.1.1, queries through 127.0.0.1, the PBR output mark, and the pbr_wan route were working after startup.

## Fix

- Capture the exact pbr ucode worker PID before detaching the prefetch process and log the PID being followed.
- Wait for that worker to exit, placing prefetch after fw4 reload, set cleanup, and the resolver restart/cache-flush request.
- Probe dnsmasq after the barrier so resolution waits until the daemon is serving again.
- Avoid a redundant second HUP on the normal PID path; PBR has already restarted dnsmasq or requested its cache flush.
- Keep the nft mtime fallback for a missing or invalid worker PID. This fallback retains its own HUP, waits one second for signal delivery, and then probes readiness.
- Keep counting NXDOMAIN lookups, but reserve the failure marker for timeouts, SERVFAIL, and other hard lookup failures.

Waiting for the captured PID avoids the ambiguity of searching the process table: it follows only the ucode worker that sourced this script, while the existing setsid plus redirected stdio keeps the service call non-blocking.

## Validation

- /bin/sh syntax check passes.
- The existing 71-test suite passes as a regression check; it does not directly exercise this user script.
- OpenWrt test package pbr 1.2.3-r101 builds and verifies successfully.
- Hardware validation on the affected MT6000 confirms the normal path logs and follows the exact worker PID. It resolved 105 domains plus one known local NXDOMAIN with no timeouts and the final success marker.
- Two reload requests submitted one second apart were serialized by the service on this router. Both prefetch runs followed their own worker PID and completed without timeout, fallback use, process leaks, or FIFO leaks.
- The missing-self branch was rechecked in an isolated shell and emits the expected warning immediately without spawning a child.

The PKG_RELEASE bump used for router testing is intentionally not included because release bumps on this branch are handled separately.