### PR TITLE
pbr-1.2.3: bump PKG_RELEASE from 99 to 101

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=pbr
 PKG_VERSION:=1.2.3
-PKG_RELEASE:=99
+PKG_RELEASE:=101
 PKG_LICENSE:=AGPL-3.0-or-later
 PKG_MAINTAINER:=Stan Grishin <stangri@melmac.ca>, Erik Conijn <egc112@msn.com>
 


### PR DESCRIPTION
What changed since **1.2.3-r99**.

One fix, in `pbr.user.dnsprefetch`:

- **The prefetch no longer reports success while leaving your policies unresolved.** This optional include resolves the domain names in your policies right after `pbr` starts or reloads, so DNS-based routing takes effect immediately instead of waiting on ordinary traffic to trigger each lookup. On a slower router, or with a large blocklist installed alongside `pbr` (a busy adblock configuration, for example), `pbr`'s own follow-up work after installing the firewall ruleset could still be running when the prefetch checked whether DNS was ready. It found a resolver that answered, went ahead, and every lookup then ran into a resolver that was mid-restart — every one timed out, and the log still said the prefetch had succeeded.

  The prefetch now waits for `pbr`'s own run to actually finish before it starts resolving, so it can no longer race the restart it depends on, and it reports failure honestly if nothing could be resolved.

Thanks to **@pesa1234**, who found this on a GL-MT6000 with a large adblock configuration and built the fix (pbr#180).

This only affects routers with the `pbr.user.dnsprefetch` include enabled — it ships disabled by default, so most installs will not have noticed it.

`PKG_RELEASE` on the `1.2.3` branch moves in steps of two and stays odd — …95, 97, 99, 101. r100 is not a skipped release; there is no even number in this series.

Paired with https://github.com/mossdef-org/luci-app-pbr/pull/52

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hxggywf8SWPPLbpZwTgHQB
