### PR TITLE
pbr-1.2.3: report a dns_policy whose dest_dns resolves to no server

### DIFF
--- a/files/lib/pbr/pbr.uc
+++ b/files/lib/pbr/pbr.uc
@@ -325,12 +325,6 @@ function create_pbr(fs_mod, uci_mod, ubus_mod) {
 		let nft_table = pkg.nft_table;
 		let nft_prefix = pkg.nft_prefix;
 	
-		if (!dest_dns_ipv4 && !dest_dns_ipv6) {
-			process_dns_policy_error = true;
-			push(state.errors, { code: 'errorPolicyProcessNoInterfaceDns', info: "'" + dest_dns + "'" });
-			return 1;
-		}
-	
 		// A rule built from exclusions alone has no positive source to take its
 		// family from, so fall back to the negated entries for the guards below
 		// and let the exclusions themselves decide which families to emit.
@@ -694,6 +688,20 @@ function create_pbr(fs_mod, uci_mod, ubus_mod) {
 		}
 		if (!dest_dns) {
 			push(state.errors, { code: 'errorPolicyNoDns', info: name });
+			output.fail(); return 1;
+		}
+		// dest_dns named something, but it resolved to no server for either
+		// family -- typically an interface whose DNS could not be determined.
+		// This has to be caught HERE. The loop below skips the ipv4 and ipv6
+		// groups for the family they lack, so a policy with a plain-address
+		// source matches only those two, emits nothing, and falls through to
+		// output.ok() -- routing nothing while reporting success.
+		// dns_policy_routing() raises the same error, but only the three
+		// family-agnostic groups (phys_dev, mac_address, domain) ever reach it,
+		// so the fault was reported for a MAC source and silent for an address.
+		if (!dest_dns_ipv4 && !dest_dns_ipv6) {
+			// bare value: the message template quotes its argument already
+			push(state.errors, { code: 'errorPolicyProcessNoInterfaceDns', info: dest_dns });
 			output.fail(); return 1;
 		}
 	

--- a/tests/04_policies/11_dns_policy_no_dns_is_reported
+++ b/tests/04_policies/11_dns_policy_no_dns_is_reported
@@ -1,0 +1,134 @@
+Testing that a dns_policy whose dest_dns resolves to nothing SAYS so.
+
+`dest_dns` is a list of tokens, each classified into one of three slots: the
+first supported interface, the first IPv4 address, the first IPv6 address. An
+interface is then resolved -- its servers fill whichever family slots are still
+empty -- so by the time the filter loop runs only two values matter,
+dest_dns_ipv4 and dest_dns_ipv6. A literal address always resolves to itself;
+an interface can resolve to nothing.
+
+When it resolves to nothing the policy cannot route, and it used to say
+nothing either. The loop pairs each source filter group with the DNS of its own
+family:
+
+	if (V.str_contains(fg, 'ipv4') && !dest_dns_ipv4) continue;
+	if (V.str_contains(fg, 'ipv6') && !dest_dns_ipv6) continue;
+
+Those two skips are correct in themselves -- a v4 source cannot be pointed at a
+server that does not exist. The fault is that nothing checks whether the loop
+emitted ANYTHING. With a plain-address source, both family groups are skipped,
+dns_policy_routing() is never called, and the function reaches output.ok() --
+no rules, no error, success reported.
+
+The error for exactly this case already existed inside dns_policy_routing(),
+but only phys_dev, mac_address and domain sources ever reached it: those groups
+carry no family, so neither skip applies to them. The same misconfiguration was
+therefore reported for a MAC source and silent for an address.
+
+`wan` is used as the unresolvable interface here: it is `proto dhcp` with no
+`option dns` in uci, and static uci is the only source this code reads.
+
+-- File uci/pbr.json --
+{
+	"pbr": [
+		{
+			".name": "config",
+			"enabled": "1",
+			"fw_mask": "00ff0000",
+			"ipv6_enabled": "0",
+			"resolver_set": "dnsmasq.nftset",
+			"uplink_interface": "wan",
+			"uplink_interface6": "wan6",
+			"uplink_ip_rules_priority": "30000",
+			"uplink_mark": "00010000",
+			"verbosity": "2",
+			"lan_device": ["br-lan"]
+		}
+	],
+	"policy": [
+	],
+	"dns_policy": [
+		{
+			".name": "dns_addr_src",
+			"name": "Addr Src",
+			"enabled": "1",
+			"src_addr": "192.168.1.10",
+			"dest_dns": "wan",
+			"dest_dns_port": "53"
+		},
+		{
+			".name": "dns_mac_src",
+			"name": "Mac Src",
+			"enabled": "1",
+			"src_addr": "00:11:22:33:44:55",
+			"dest_dns": "wan",
+			"dest_dns_port": "53"
+		},
+		{
+			".name": "dns_works",
+			"name": "Works",
+			"enabled": "1",
+			"src_addr": "192.168.1.11",
+			"dest_dns": "1.1.1.1",
+			"dest_dns_port": "53"
+		}
+	],
+	"include": [
+	]
+}
+-- End --
+
+-- Testcase --
+import create_pbr from 'pbr';
+let pbr = create_pbr();
+
+let result = pbr.start_service(['on_start']);
+let nft = global.mocklib.read_captured('/var/run/pbr.nft') || '';
+
+function rules_for(n) {
+	return filter(split(nft, '\n'), l => index(l, 'comment "' + n + '"') >= 0);
+}
+function no_dns_errors() {
+	return filter(result.errors || [],
+		e => e.code == 'errorPolicyProcessNoInterfaceDns');
+}
+
+let checks = [
+	// 1. the case that was silent: an address source pointed at an interface
+	//    with no resolvable DNS. It must not route, and it must say why.
+	['addr_src_no_rules',   length(rules_for('Addr Src')) == 0],
+	['addr_src_reported',   length(no_dns_errors()) > 0],
+
+	// 2. the source kind must not decide whether the fault is reported. The
+	//    MAC policy reached the error before this change and still must.
+	//    The exact count also pins down WHERE the check lives: rejecting the
+	//    policy up front gives one error each, while checking inside the
+	//    filter loop would give 'Addr Src' one per matching group.
+	['mac_src_no_rules',    length(rules_for('Mac Src')) == 0],
+	['both_sources_report', length(no_dns_errors()) == 2],
+
+	// 3. the error names what the user wrote in dest_dns
+	['error_names_dest',    length(filter(no_dns_errors(),
+		e => index('' + e.info, 'wan') >= 0)) == 2],
+
+	// 4. rejecting these two must not disturb a policy that does resolve
+	['working_policy_kept', length(rules_for('Works')) > 0],
+	['working_policy_dnat', length(filter(rules_for('Works'),
+		l => index(l, '1.1.1.1') >= 0)) > 0],
+];
+
+let pass = 0, fail = 0;
+for (let c in checks) {
+	if (c[1]) {
+		pass++;
+	} else {
+		fail++;
+		printf("FAIL: %s\n", c[0]);
+	}
+}
+printf("dns_policy_no_dns_is_reported: %d/%d passed\n", pass, pass + fail);
+-- End --
+
+-- Expect stdout --
+dns_policy_no_dns_is_reported: 7/7 passed
+-- End --


### PR DESCRIPTION
A `dns_policy` pointed at an interface with no determinable DNS routed nothing
and said nothing — `output.ok()`, no rules, no message.

### Why it was silent

`dest_dns` is a list of tokens sorted into three slots: the first supported
interface, the first IPv4 address, the first IPv6 address. An interface is then
*resolved*, filling whichever family slots are still empty, so downstream only
`dest_dns_ipv4` and `dest_dns_ipv6` matter. A literal address always resolves to
itself; an interface can resolve to nothing.

When it does, the filter loop pairs each source group with the DNS of its own
family and skips the ones it cannot serve:

```ucode
if (V.str_contains(fg, 'ipv4') && !dest_dns_ipv4) continue;
if (V.str_contains(fg, 'ipv6') && !dest_dns_ipv6) continue;
```

Both skips are correct — a v4 source cannot be pointed at a server that does not
exist. What was missing is any check that the loop emitted **anything**. With a
plain-address source both family groups are skipped, `dns_policy_routing()` is
never called, and the function falls through to `output.ok()`.

The error for this case already existed inside `dns_policy_routing()`, but only
`phys_dev`, `mac_address` and `domain` sources reached it — those groups carry
no family, so neither skip applies. The same misconfiguration was therefore
**reported for a MAC source and silent for an address**.

### The change

Reject it in `dns_policy_process()`, before the loop. That covers every source
kind uniformly and yields one error per policy rather than one per matching
filter group. The two `continue`s are untouched.

The check inside `dns_policy_routing()` is removed: rejecting the policy up
front makes it unreachable from both call sites, and the function is private
with no other callers. Its `dest_dns` parameter stays — the family-mismatch
error below it still names it.

### Also fixes the doubled quoting

The old call site passed ``info: "'" + dest_dns + "'"`` while the template
already quotes its argument (`"Interface '%s' has no assigned DNS"`, `pkg.uc`),
so it rendered as:

```
Interface ''wan'' has no assigned DNS
```

That was the only such site in the file. The new one passes the bare value, so
no double-quoted `info` remains anywhere.

### Scope

This is the **both-families-empty** case only. A half-resolved `dest_dns` — a
literal v6 address with a v4-only source, say — is still silently skipped. That
is a family mismatch rather than a missing server, and the existing message
would read `Interface '2606:4700:4700::1111' has no assigned DNS`, wrong on both
counts. Describing it needs a new message code, so it is left for a later
change.

No new message code and no text change here, so **no compat bump**.

### Testing

New test `04_policies/11_dns_policy_no_dns_is_reported` — 7 checks, **5/7
without this change**. It asserts the error count is exactly 2 across an
address-source and a MAC-source policy, which pins down both that the source
kind no longer decides whether the fault is reported and that the check sits
before the loop rather than inside it.

Full suite 72/72. ucode syntax gate 17/17 against the pinned interpreter.
